### PR TITLE
Fix anon perms to allow web UI to work

### DIFF
--- a/deployment/boundary/roles.tf
+++ b/deployment/boundary/roles.tf
@@ -1,7 +1,7 @@
 resource "boundary_role" "org_admin" {
   scope_id       = boundary_scope.global.id
   grant_scope_id = boundary_scope.org.id
-  grant_strings  = ["id=*;actions=*"]
+  grant_strings  = ["id=*;actions=*;type=*"]
   principal_ids = concat(
     [for user in boundary_user.backend : user.id],
     [for user in boundary_user.frontend : user.id],
@@ -14,12 +14,18 @@ resource "boundary_role" "org_anon_listing" {
   principal_ids = ["u_anon"]
 }
 
+resource "boundary_role" "global_anon" {
+  scope_id = boundary_scope.global.id
+  grant_strings = ["id=*;type=scope;actions=list,read", "id=*;type=auth-method;actions=read,list"]
+  principal_ids = ["u_anon"]
+}
+
 // add org-level role for readonly access
 resource "boundary_role" "organization_readonly" {
   name          = "readonly"
   description   = "Read-only role"
   principal_ids = [boundary_group.leadership.id]
-  grant_strings = ["id=*;actions=read"]
+  grant_strings = ["id=*;type=*;actions=read"]
   scope_id      = boundary_scope.org.id
 }
 
@@ -30,5 +36,5 @@ resource "boundary_role" "project_admin" {
   scope_id       = boundary_scope.org.id
   grant_scope_id = boundary_scope.core_infra.id
   principal_ids  = ["u_auth"]
-  grant_strings  = ["id=*;actions=*"]
+  grant_strings  = ["id=*;type=*;actions=*"]
 }

--- a/deployment/boundary/scopes.tf
+++ b/deployment/boundary/scopes.tf
@@ -15,5 +15,5 @@ resource "boundary_scope" "core_infra" {
   name             = "core_infra"
   description      = "Backend infrastrcture project"
   scope_id         = boundary_scope.org.id
-  auto_create_role = true
+  # auto_create_role = true
 }


### PR DESCRIPTION
I've slightly adjusted the roles definition so that the anon user can query global scopes & auth-methods. These two acls seem to be required for the UI to function (as of https://github.com/hashicorp/boundary/commit/dc379ed09f6afa0ef5f7692f87d76d2e9664aedd)

I _believe_ that this is the necessary minimum amount of privileges, but I'm unsure if all the `read`s are required.