### PR TITLE
GCP Boundary Reference Architecture

### DIFF
--- a/deployment/gcp/README.md
+++ b/deployment/gcp/README.md
@@ -50,3 +50,26 @@ Connect to the target in the private subnet via Boundary:
 BOUNDARY_ADDR='http://<boundary_url>' \
   boundary connect ssh --username ubuntu -target-id ttcp_<generated_id>
 ```
+
+# Other important notes
+Singe the Google Certificate Authority Service (CAS) is in beta, there may be some interesting behaviours to manage.
+
+A few things to note:
+1. Server certificates are created with a TTL of 30 days, you will need to modify your configuration or set up some a cronjob to manage this. The commands to do so are:
+```
+export CLOUDSDK_PYTHON_SITEPACKAGES=1
+gcloud beta privateca certificates create \
+  --issuer ${ca_name} \
+	--issuer-location ${ca_issuer_location} \
+  --generate-key \
+  --key-output-file ${tls_key_path}/worker.key \
+  --cert-output-file ${tls_cert_path}/worker.crt \
+  --ip-san ${worker_listener_ip} \
+  --reusable-config "leaf-server-tls"
+export CLOUDSDK_PYTHON_SITEPACKAGES=0
+```
+Note that the required python packages to support this have been scoped to the root user by the startup script.
+
+3. This module defaults the location of the CAS service to asia-east1. It is only available in limited regions during the beta phase, if you are uncomfortable with this then you should set the variable `ca_issuer_location` to an alternative supported value.
+
+4. Finally, since these certificates are self-signed, you will experience UI/CLI errors if you do not trust the root CA generated for this purpose. We opted out of adding an intermediate CA at this moment in time as it requires intervention in the UI. Trusting the root will allow you to connect to different compute nodes as the group scales out or replaces nodes.

--- a/deployment/gcp/README.md
+++ b/deployment/gcp/README.md
@@ -1,0 +1,52 @@
+# Boundary Deployment Examples
+This directory contains two deployment examples for Boundary using Terraform. The `gcp/` directory contains an example AWS reference architecture codified in Terraform. The `boundary/` directory contains an example Terraform configuration for Boundary using the [Boundary Terraform Provider](https://github.com/hashicorp/terraform-provider-boundary).
+
+## Requirements
+- Terraform 0.13 or later
+
+## Deploy
+To deploy this example:
+- In the `example` directory, run:
+
+```
+terraform apply
+```
+
+SSH is disabled by default, but can be toggled on with `-var enable_ssh=true`. To connect, you will need to set the absolute path to your ssh public key with `-var ssh_key_path=path_to_my_ssh_key/id_rsa.pub`.
+
+TLS is enabled by default, and leverages the beta certificate authority service on GCP.
+
+## Verify
+- Once your GCP infra is live, you can SSH to your workers and controllers and see their configuration:
+  - `ssh ubuntu@<controller-ip>`
+  - `sudo systemctl status boundary-controller`
+  - For workers, the systemd unit is called `boundary-worker`
+  - The admin console url will be passed through as an output.
+
+## Configure Boundary
+- Configure boundary by changing into the boundary directoy, and using `terraform apply` (without the target flag), this will configure boundary per `boundary/main.tf`
+
+## Login
+- Open the console in a browser and login to the instance using one of the `backend_users` defined in the main.tf (or, if you saved the output from deploying the aws module, use the output from the init script for the default username/password)
+- Find your org, then project, then targets. Save the ID of the target.
+- Find your auth methods, and save the auth method ID.
+- Login on the CLI:
+
+```
+BOUNDARY_ADDR='https://<boundary_url>' \
+  boundary authenticate password \
+  -login-name=jim \
+  -password foofoofoo \
+  -auth-method-id=ampw_<some ID>
+```
+
+You can also use this login name in the Boundary console that you navigated to in the verify step.
+
+## Connect
+
+Connect to the target in the private subnet via Boundary:
+
+```
+BOUNDARY_ADDR='http://<boundary_url>' \
+  boundary connect ssh --username ubuntu -target-id ttcp_<generated_id>
+```

--- a/deployment/gcp/boundary/auth.tf
+++ b/deployment/gcp/boundary/auth.tf
@@ -1,0 +1,6 @@
+resource "boundary_auth_method" "password" {
+  name        = "corp_password_auth_method"
+  description = "Password auth method for Corp org"
+  type        = "password"
+  scope_id    = boundary_scope.org.id
+}

--- a/deployment/gcp/boundary/hosts.tf
+++ b/deployment/gcp/boundary/hosts.tf
@@ -1,0 +1,23 @@
+resource "boundary_host_catalog" "backend_servers" {
+  name        = "backend_servers"
+  description = "Web servers for backend team"
+  type        = "static"
+  scope_id    = boundary_scope.core_infra.id
+}
+
+resource "boundary_host" "backend_servers" {
+  for_each        = var.target_ips
+  type            = "static"
+  name            = "backend_server_${each.value}"
+  description     = "Backend server #${each.value}"
+  address         = each.key
+  host_catalog_id = boundary_host_catalog.backend_servers.id
+}
+
+resource "boundary_host_set" "backend_servers" {
+  type            = "static"
+  name            = "backend_servers"
+  description     = "Host set for backend servers"
+  host_catalog_id = boundary_host_catalog.backend_servers.id
+  host_ids        = [for host in boundary_host.backend_servers : host.id]
+}

--- a/deployment/gcp/boundary/main.tf
+++ b/deployment/gcp/boundary/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    boundary = {
+      source  = "hashicorp/boundary"
+      version = "1.0.1"
+    }
+  }
+}
+
+provider "boundary" {
+  addr             = var.url
+  recovery_kms_hcl = <<EOT
+kms "gcpckms" {
+  purpose     = "recovery"
+  key_ring    = "${var.key_ring}"
+  crypto_key  = "${var.recovery_key}"
+	project     = "${var.gcp_project}"
+	region      = "global"
+}
+EOT
+}

--- a/deployment/gcp/boundary/principals.tf
+++ b/deployment/gcp/boundary/principals.tf
@@ -1,0 +1,76 @@
+resource "boundary_user" "backend" {
+  for_each    = var.backend_team
+  name        = each.key
+  description = "Backend user: ${each.key}"
+  account_ids = [boundary_account.backend_user_acct[each.value].id]
+  scope_id    = boundary_scope.org.id
+}
+
+resource "boundary_user" "frontend" {
+  for_each    = var.frontend_team
+  name        = each.key
+  description = "Frontend user: ${each.key}"
+  account_ids = [boundary_account.frontend_user_acct[each.value].id]
+  scope_id    = boundary_scope.org.id
+}
+
+resource "boundary_user" "leadership" {
+  for_each    = var.leadership_team
+  name        = each.key
+  description = "WARNING: Managers should be read-only"
+  account_ids = [boundary_account.leadership_user_acct[each.value].id]
+  scope_id    = boundary_scope.org.id
+}
+
+resource "boundary_account" "backend_user_acct" {
+  for_each       = var.backend_team
+  name           = each.key
+  description    = "User account for ${each.key}"
+  type           = "password"
+  login_name     = lower(each.key)
+  password       = "foofoofoo"
+  auth_method_id = boundary_auth_method.password.id
+}
+
+resource "boundary_account" "frontend_user_acct" {
+  for_each       = var.frontend_team
+  name           = each.key
+  description    = "User account for ${each.key}"
+  type           = "password"
+  login_name     = lower(each.key)
+  password       = "foofoofoo"
+  auth_method_id = boundary_auth_method.password.id
+}
+
+resource "boundary_account" "leadership_user_acct" {
+  for_each       = var.leadership_team
+  name           = each.key
+  description    = "User account for ${each.key}"
+  type           = "password"
+  login_name     = lower(each.key)
+  password       = "foofoofoo"
+  auth_method_id = boundary_auth_method.password.id
+}
+
+// organiation level group for the leadership team
+resource "boundary_group" "leadership" {
+  name        = "leadership_team"
+  description = "Organization group for leadership team"
+  member_ids  = [for user in boundary_user.leadership : user.id]
+  scope_id    = boundary_scope.org.id
+}
+
+// project level group for backend and frontend management of core infra
+resource "boundary_group" "backend_core_infra" {
+  name        = "backend"
+  description = "Backend team group"
+  member_ids  = [for user in boundary_user.backend : user.id]
+  scope_id    = boundary_scope.core_infra.id
+}
+
+resource "boundary_group" "frontend_core_infra" {
+  name        = "frontend"
+  description = "Frontend team group"
+  member_ids  = [for user in boundary_user.frontend : user.id]
+  scope_id    = boundary_scope.core_infra.id
+}

--- a/deployment/gcp/boundary/principles.tf
+++ b/deployment/gcp/boundary/principles.tf
@@ -1,0 +1,76 @@
+resource "boundary_user" "backend" {
+  for_each    = var.backend_team
+  name        = each.key
+  description = "Backend user: ${each.key}"
+  account_ids = [boundary_account.backend_user_acct[each.value].id]
+  scope_id    = boundary_scope.org.id
+}
+
+resource "boundary_user" "frontend" {
+  for_each    = var.frontend_team
+  name        = each.key
+  description = "Frontend user: ${each.key}"
+  account_ids = [boundary_account.frontend_user_acct[each.value].id]
+  scope_id    = boundary_scope.org.id
+}
+
+resource "boundary_user" "leadership" {
+  for_each    = var.leadership_team
+  name        = each.key
+  description = "WARNING: Managers should be read-only"
+  account_ids = [boundary_account.leadership_user_acct[each.value].id]
+  scope_id    = boundary_scope.org.id
+}
+
+resource "boundary_account" "backend_user_acct" {
+  for_each       = var.backend_team
+  name           = each.key
+  description    = "User account for ${each.key}"
+  type           = "password"
+  login_name     = lower(each.key)
+  password       = "foofoofoo"
+  auth_method_id = boundary_auth_method.password.id
+}
+
+resource "boundary_account" "frontend_user_acct" {
+  for_each       = var.frontend_team
+  name           = each.key
+  description    = "User account for ${each.key}"
+  type           = "password"
+  login_name     = lower(each.key)
+  password       = "foofoofoo"
+  auth_method_id = boundary_auth_method.password.id
+}
+
+resource "boundary_account" "leadership_user_acct" {
+  for_each       = var.leadership_team
+  name           = each.key
+  description    = "User account for ${each.key}"
+  type           = "password"
+  login_name     = lower(each.key)
+  password       = "foofoofoo"
+  auth_method_id = boundary_auth_method.password.id
+}
+
+// organiation level group for the leadership team
+resource "boundary_group" "leadership" {
+  name        = "leadership_team"
+  description = "Organization group for leadership team"
+  member_ids  = [for user in boundary_user.leadership : user.id]
+  scope_id    = boundary_scope.org.id
+}
+
+// project level group for backend and frontend management of core infra
+resource "boundary_group" "backend_core_infra" {
+  name        = "backend"
+  description = "Backend team group"
+  member_ids  = [for user in boundary_user.backend : user.id]
+  scope_id    = boundary_scope.core_infra.id
+}
+
+resource "boundary_group" "frontend_core_infra" {
+  name        = "frontend"
+  description = "Frontend team group"
+  member_ids  = [for user in boundary_user.frontend : user.id]
+  scope_id    = boundary_scope.core_infra.id
+}

--- a/deployment/gcp/boundary/roles.tf
+++ b/deployment/gcp/boundary/roles.tf
@@ -1,0 +1,70 @@
+# Allows anonymous (un-authenticated) users to list and authenticate against any
+# auth method, list the global scope, and read and change password on their account ID
+# at the global scope
+resource "boundary_role" "global_anon_listing" {
+  scope_id = boundary_scope.global.id
+  grant_strings = [
+    "id=*;type=auth-method;actions=list,authenticate",
+    "type=scope;actions=list",
+    "id={{account.id}};actions=read,change-password"
+  ]
+  principal_ids = ["u_anon"]
+}
+
+# Allows anonymous (un-authenticated) users to list and authenticate against any
+# auth method, list the global scope, and read and change password on their account ID
+# at the org level scope
+resource "boundary_role" "org_anon_listing" {
+  scope_id = boundary_scope.org.id
+  grant_strings = [
+    "id=*;type=auth-method;actions=list,authenticate",
+    "type=scope;actions=list",
+    "id={{account.id}};actions=read,change-password"
+  ]
+  principal_ids = ["u_anon"]
+}
+
+# Creates a role in the global scope that's granting administrative access to 
+# resources in the org scope for all backend users
+resource "boundary_role" "org_admin" {
+  scope_id       = boundary_scope.global.id
+  grant_scope_id = boundary_scope.org.id
+  grant_strings = [
+    "id=*;type=*;actions=*"
+  ]
+  principal_ids = concat(
+    [for user in boundary_user.backend : user.id],
+    [for user in boundary_user.frontend : user.id],
+  )
+}
+
+# Adds a read-only role in the global scope granting read-only access
+# to all resources within the org scope and adds principals from the 
+# leadership team to the role
+resource "boundary_role" "org_readonly" {
+  name        = "readonly"
+  description = "Read-only role"
+  principal_ids = [
+    boundary_group.leadership.id
+  ]
+  grant_strings = [
+    "id=*;type=*;actions=read"
+  ]
+  scope_id       = boundary_scope.global.id
+  grant_scope_id = boundary_scope.org.id
+}
+
+# Adds an org-level role granting administrative permissions within the core_infra project
+resource "boundary_role" "project_admin" {
+  name           = "core_infra_admin"
+  description    = "Administrator role for core infra"
+  scope_id       = boundary_scope.org.id
+  grant_scope_id = boundary_scope.core_infra.id
+  grant_strings = [
+    "id=*;type=*;actions=*"
+  ]
+  principal_ids = concat(
+    [for user in boundary_user.backend : user.id],
+    [for user in boundary_user.frontend : user.id],
+  )
+}

--- a/deployment/gcp/boundary/scopes.tf
+++ b/deployment/gcp/boundary/scopes.tf
@@ -1,0 +1,20 @@
+resource "boundary_scope" "global" {
+  global_scope = true
+  name         = "global"
+  scope_id     = "global"
+}
+
+resource "boundary_scope" "org" {
+  scope_id    = boundary_scope.global.id
+  name        = "organization"
+  description = "Organization scope"
+}
+
+// create a project for core infrastructure
+resource "boundary_scope" "core_infra" {
+  name                     = "core_infra"
+  description              = "Backend infrastrcture project"
+  scope_id                 = boundary_scope.org.id
+  auto_create_admin_role   = true
+  auto_create_default_role = true
+}

--- a/deployment/gcp/boundary/targets.tf
+++ b/deployment/gcp/boundary/targets.tf
@@ -1,0 +1,23 @@
+resource "boundary_target" "backend_servers_ssh" {
+  type                     = "tcp"
+  name                     = "backend_servers_ssh"
+  description              = "Backend SSH target"
+  scope_id                 = boundary_scope.core_infra.id
+  session_connection_limit = -1
+  default_port             = 22
+  host_set_ids = [
+    boundary_host_set.backend_servers.id
+  ]
+}
+
+resource "boundary_target" "backend_servers_website" {
+  type                     = "tcp"
+  name                     = "backend_servers_website"
+  description              = "Backend website target"
+  scope_id                 = boundary_scope.core_infra.id
+  session_connection_limit = -1
+  default_port             = 8000
+  host_set_ids = [
+    boundary_host_set.backend_servers.id
+  ]
+}

--- a/deployment/gcp/boundary/vars.tf
+++ b/deployment/gcp/boundary/vars.tf
@@ -1,0 +1,48 @@
+variable "url" {
+  default = "http://127.0.0.1:9200"
+  #  default = "http://boundary-demo-controller-ec52c62e6a9979ab.elb.us-east-1.amazonaws.com:9200"
+}
+
+variable "backend_team" {
+  type = set(string)
+  default = [
+    "jim",
+    "mike",
+    "todd",
+  ]
+}
+
+variable "frontend_team" {
+  type = set(string)
+  default = [
+    "randy",
+    "susmitha",
+  ]
+}
+
+variable "leadership_team" {
+  type = set(string)
+  default = [
+    "jeff",
+    "pete",
+    "jonathan",
+    "malnick"
+  ]
+}
+
+variable "target_ips" {
+  type    = set(string)
+  default = []
+}
+
+variable "key_ring" {
+	type = string
+}
+
+variable "recovery_key" {
+	type = string
+}
+
+variable "gcp_project" {
+	type = string
+}

--- a/deployment/gcp/gcp/compute.tf
+++ b/deployment/gcp/gcp/compute.tf
@@ -70,14 +70,6 @@ resource "google_compute_region_instance_group_manager" "controller" {
   }
 
   base_instance_name = local.boundary_name
-
-	update_policy {
-		type                         = "PROACTIVE"
-		instance_redistribution_type = "PROACTIVE"
-		minimal_action               = "REPLACE"
-		min_ready_sec                = 50
-		replacement_method           = "RECREATE"
-	}
 }
 
 resource "google_compute_region_autoscaler" "controller" {
@@ -100,14 +92,6 @@ resource "google_compute_region_instance_group_manager" "worker" {
   }
 
   base_instance_name = local.boundary_name
-
-	update_policy {
-		type                         = "PROACTIVE"
-		instance_redistribution_type = "PROACTIVE"
-		minimal_action               = "REPLACE"
-		min_ready_sec                = 50
-		replacement_method           = "RECREATE"
-	}
 }
 
 resource "google_compute_region_autoscaler" "worker" {

--- a/deployment/gcp/gcp/compute.tf
+++ b/deployment/gcp/gcp/compute.tf
@@ -30,27 +30,23 @@ resource "google_compute_instance_template" "controller" {
   metadata = {
     ssh-keys = local.ssh_key_string
   }
-  metadata_startup_script = templatefile("${path.module}/templates/boundary.hcl.tpl", {
+  metadata_startup_script = templatefile("${path.module}/templates/controller.hcl.tpl", {
     boundary_version               = var.boundary_version
-    type                           = "controller"
-    ca_name                        = google_privateca_certificate_authority.this.certificate_authority_id
-		ca_issuer_location             = var.ca_issuer_location
+    ca_name                        = var.tls_disabled == true ? null : google_privateca_certificate_authority.this[0].certificate_authority_id
+		ca_issuer_location             = var.tls_disabled == true ? null : var.ca_issuer_location
     controller_api_listener_ip     = google_compute_address.public_controller_api.address
     controller_cluster_listener_ip = google_compute_address.public_controller_cluster.address
     controller_api_port            = var.controller_api_port
     controller_cluster_port        = var.controller_cluster_port
-    worker_listener_ip             = google_compute_address.public_worker.address
-    worker_port                    = var.worker_port
     project_id                     = var.project
     public_cluster_address         = google_compute_address.public_controller_cluster.address
-    public_worker_address          = google_compute_address.public_worker.address
     db_endpoint                    = google_sql_database_instance.this.private_ip_address
     db_name                        = google_sql_database.this.name
     db_username                    = var.boundary_database_username
     db_password                    = var.boundary_database_password
     tls_disabled                   = var.tls_disabled
-    tls_key_path                   = var.tls_key_path
-    tls_cert_path                  = var.tls_cert_path
+    tls_key_path                   = var.tls_disabled == true ? null : var.tls_key_path
+    tls_cert_path                  = var.tls_disabled == true ? null : var.tls_cert_path
     kms_key_ring                   = google_kms_key_ring.this.name
     kms_worker_auth_key_id         = google_kms_crypto_key.worker_auth.name
     kms_recovery_key_id            = google_kms_crypto_key.recovery.name
@@ -134,27 +130,18 @@ resource "google_compute_instance_template" "worker" {
   metadata = {
     ssh-keys = local.ssh_key_string
   }
-  metadata_startup_script = templatefile("${path.module}/templates/boundary.hcl.tpl", {
+  metadata_startup_script = templatefile("${path.module}/templates/worker.hcl.tpl", {
     boundary_version               = var.boundary_version
-    type                           = "worker"
-    ca_name                        = google_privateca_certificate_authority.this.certificate_authority_id
-		ca_issuer_location             = var.ca_issuer_location
-    controller_api_listener_ip     = google_compute_address.public_controller_api.address
-    controller_cluster_listener_ip = google_compute_address.public_controller_cluster.address
-    controller_api_port            = var.controller_api_port
-    controller_cluster_port        = var.controller_cluster_port
+    ca_name                        = var.tls_disabled == true ? null : google_privateca_certificate_authority.this[0].certificate_authority_id
+		ca_issuer_location             = var.tls_disabled == true ? null : var.ca_issuer_location
     worker_listener_ip             = google_compute_address.public_worker.address
     worker_port                    = var.worker_port
     project_id                     = var.project
     public_cluster_address         = google_compute_address.public_controller_cluster.address
     public_worker_address          = google_compute_address.public_worker.address
-    db_endpoint                    = google_sql_database_instance.this.private_ip_address
-    db_name                        = google_sql_database.this.name
-    db_username                    = var.boundary_database_username
-    db_password                    = var.boundary_database_password
     tls_disabled                   = var.tls_disabled
-    tls_key_path                   = var.tls_key_path
-    tls_cert_path                  = var.tls_cert_path
+    tls_key_path                   = var.tls_disabled == true ? null : var.tls_key_path
+    tls_cert_path                  = var.tls_disabled == true ? null : var.tls_cert_path
     kms_key_ring                   = google_kms_key_ring.this.name
     kms_worker_auth_key_id         = google_kms_crypto_key.worker_auth.name
     kms_recovery_key_id            = google_kms_crypto_key.recovery.name

--- a/deployment/gcp/gcp/compute.tf
+++ b/deployment/gcp/gcp/compute.tf
@@ -152,7 +152,7 @@ resource "google_compute_instance_template" "worker" {
   }
   metadata_startup_script = templatefile("${path.module}/templates/boundary.hcl.tpl", {
     boundary_version               = var.boundary_version
-    type                           = "controller"
+    type                           = "worker"
     ca_name                        = google_privateca_certificate_authority.this.certificate_authority_id
 		ca_issuer_location             = var.ca_issuer_location
     controller_api_listener_ip     = google_compute_address.public_controller_api.address

--- a/deployment/gcp/gcp/compute.tf
+++ b/deployment/gcp/gcp/compute.tf
@@ -1,0 +1,204 @@
+data "google_compute_image" "this" {
+  family  = var.compute_image_family
+  project = var.compute_image_project
+}
+
+resource "google_compute_instance_template" "controller" {
+  name_prefix    = local.boundary_controller_name
+  machine_type   = var.compute_machine_type
+  can_ip_forward = var.enable_ssh
+
+  disk {
+    source_image = data.google_compute_image.this.id
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.controller.id
+    dynamic "access_config" {
+      for_each = var.enable_ssh == true ? [0] : []
+      content {}
+    }
+  }
+
+  service_account {
+    email  = google_service_account.boundary_controller.email
+    scopes = ["cloud-platform"]
+  }
+
+  tags = var.boundary_controller_tags
+
+  metadata = {
+    ssh-keys = local.ssh_key_string
+  }
+  metadata_startup_script = templatefile("${path.module}/templates/boundary.hcl.tpl", {
+    boundary_version               = var.boundary_version
+    type                           = "controller"
+    ca_name                        = google_privateca_certificate_authority.this.certificate_authority_id
+		ca_issuer_location             = var.ca_issuer_location
+    controller_api_listener_ip     = google_compute_address.public_controller_api.address
+    controller_cluster_listener_ip = google_compute_address.public_controller_cluster.address
+    controller_api_port            = var.controller_api_port
+    controller_cluster_port        = var.controller_cluster_port
+    worker_listener_ip             = google_compute_address.public_worker.address
+    worker_port                    = var.worker_port
+    project_id                     = var.project
+    public_cluster_address         = google_compute_address.public_controller_cluster.address
+    public_worker_address          = google_compute_address.public_worker.address
+    db_endpoint                    = google_sql_database_instance.this.private_ip_address
+    db_name                        = google_sql_database.this.name
+    db_username                    = var.boundary_database_username
+    db_password                    = var.boundary_database_password
+    tls_disabled                   = var.tls_disabled
+    tls_key_path                   = var.tls_key_path
+    tls_cert_path                  = var.tls_cert_path
+    kms_key_ring                   = google_kms_key_ring.this.name
+    kms_worker_auth_key_id         = google_kms_crypto_key.worker_auth.name
+    kms_recovery_key_id            = google_kms_crypto_key.recovery.name
+    kms_root_key_id                = google_kms_crypto_key.root.name
+  })
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_region_instance_group_manager" "controller" {
+  name = local.boundary_controller_name
+
+  version {
+    instance_template = google_compute_instance_template.controller.id
+    name              = var.boundary_version
+  }
+
+  base_instance_name = local.boundary_name
+
+	update_policy {
+		type                         = "PROACTIVE"
+		instance_redistribution_type = "PROACTIVE"
+		minimal_action               = "REPLACE"
+		min_ready_sec                = 50
+		replacement_method           = "RECREATE"
+	}
+}
+
+resource "google_compute_region_autoscaler" "controller" {
+  name   = local.boundary_controller_name
+  target = google_compute_region_instance_group_manager.controller.id
+
+  autoscaling_policy {
+    max_replicas    = var.max_controller_replicas
+    min_replicas    = var.min_controller_replicas
+    cooldown_period = 60
+  }
+}
+
+resource "google_compute_region_instance_group_manager" "worker" {
+  name = local.boundary_worker_name
+
+  version {
+    instance_template = google_compute_instance_template.worker.id
+    name              = var.boundary_version
+  }
+
+  base_instance_name = local.boundary_name
+
+	update_policy {
+		type                         = "PROACTIVE"
+		instance_redistribution_type = "PROACTIVE"
+		minimal_action               = "REPLACE"
+		min_ready_sec                = 50
+		replacement_method           = "RECREATE"
+	}
+}
+
+resource "google_compute_region_autoscaler" "worker" {
+  name   = local.boundary_worker_name
+  target = google_compute_region_instance_group_manager.worker.id
+
+  autoscaling_policy {
+    max_replicas    = var.max_worker_replicas
+    min_replicas    = var.min_worker_replicas
+    cooldown_period = 60
+  }
+}
+
+resource "google_compute_instance_template" "worker" {
+
+  name_prefix    = local.boundary_worker_name
+  machine_type   = var.compute_machine_type
+  can_ip_forward = var.enable_ssh
+
+  disk {
+    source_image = data.google_compute_image.this.id
+  }
+
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.worker.id
+    dynamic "access_config" {
+      for_each = var.enable_ssh == true ? [0] : []
+      content {}
+    }
+  }
+
+  service_account {
+    email  = google_service_account.boundary_worker.email
+    scopes = ["cloud-platform"]
+  }
+
+  tags = var.boundary_worker_tags
+
+  metadata = {
+    ssh-keys = local.ssh_key_string
+  }
+  metadata_startup_script = templatefile("${path.module}/templates/boundary.hcl.tpl", {
+    boundary_version               = var.boundary_version
+    type                           = "controller"
+    ca_name                        = google_privateca_certificate_authority.this.certificate_authority_id
+		ca_issuer_location             = var.ca_issuer_location
+    controller_api_listener_ip     = google_compute_address.public_controller_api.address
+    controller_cluster_listener_ip = google_compute_address.public_controller_cluster.address
+    controller_api_port            = var.controller_api_port
+    controller_cluster_port        = var.controller_cluster_port
+    worker_listener_ip             = google_compute_address.public_worker.address
+    worker_port                    = var.worker_port
+    project_id                     = var.project
+    public_cluster_address         = google_compute_address.public_controller_cluster.address
+    public_worker_address          = google_compute_address.public_worker.address
+    db_endpoint                    = google_sql_database_instance.this.private_ip_address
+    db_name                        = google_sql_database.this.name
+    db_username                    = var.boundary_database_username
+    db_password                    = var.boundary_database_password
+    tls_disabled                   = var.tls_disabled
+    tls_key_path                   = var.tls_key_path
+    tls_cert_path                  = var.tls_cert_path
+    kms_key_ring                   = google_kms_key_ring.this.name
+    kms_worker_auth_key_id         = google_kms_crypto_key.worker_auth.name
+    kms_recovery_key_id            = google_kms_crypto_key.recovery.name
+    kms_root_key_id                = google_kms_crypto_key.root.name
+  })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_firewall" "ssh" {
+  count   = var.enable_ssh == true ? 1 : 0
+  name    = "temporary-ssh-access"
+  network = google_compute_network.this.name
+
+  source_ranges = [var.my_public_ip]
+
+  allow {
+    protocol = "tcp"
+    ports = [
+      22
+    ]
+  }
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+  target_tags = concat(var.boundary_controller_tags, var.boundary_worker_tags)
+
+  direction = "INGRESS"
+}

--- a/deployment/gcp/gcp/db.tf
+++ b/deployment/gcp/gcp/db.tf
@@ -1,0 +1,30 @@
+resource "google_sql_database_instance" "this" {
+  depends_on = [
+    google_compute_global_address.this,
+    google_service_networking_connection.this
+  ]
+  name                = local.boundary_name
+  database_version    = var.postgres_version
+  deletion_protection = false
+
+  settings {
+    tier              = var.database_tier
+    availability_type = "REGIONAL"
+    ip_configuration {
+      ipv4_enabled    = true
+      private_network = google_compute_network.this.id
+      require_ssl     = false
+    }
+  }
+}
+
+resource "google_sql_database" "this" {
+  name     = local.boundary_name
+  instance = google_sql_database_instance.this.name
+}
+
+resource "google_sql_user" "this" {
+  name     = var.boundary_database_username
+  instance = google_sql_database_instance.this.name
+  password = var.boundary_database_password
+}

--- a/deployment/gcp/gcp/iam.tf
+++ b/deployment/gcp/gcp/iam.tf
@@ -55,6 +55,7 @@ resource "google_kms_crypto_key_iam_policy" "recovery" {
 
 ### IAM policy for certificate generation
 data "google_iam_policy" "cas" {
+	count = var.tls_disabled == true ? 0 : 1
   provider = google-beta
   binding {
     role = "roles/privateca.certificateManager"
@@ -66,32 +67,8 @@ data "google_iam_policy" "cas" {
 }
 
 resource "google_privateca_certificate_authority_iam_policy" "cas" {
+	count = var.tls_disabled == true ? 0 : 1
   provider              = google-beta
-  certificate_authority = google_privateca_certificate_authority.this.id
-  policy_data           = data.google_iam_policy.cas.policy_data
+  certificate_authority = google_privateca_certificate_authority.this[0].id
+  policy_data           = data.google_iam_policy.cas[0].policy_data
 }
-
-### IAM for logging
-data "google_iam_policy" "logging" {
-  provider = google-beta
-  binding {
-    role = "roles/stackdriver.resourceMetadata.writer"
-    members = [
-      "serviceAccount:${google_service_account.boundary_controller.email}",
-      "serviceAccount:${google_service_account.boundary_worker.email}"
-    ]
-  }
-}
-
-# resource "google_compute_instance_iam_policy" "controller_logging" {
-#   instance_name = google_compute_instance_template.controller.name
-#   policy_data = data.google_iam_policy.logging.policy_data
-# }
-
-# resource "google_compute_instance_iam_policy" "worker_logging" {
-#   instance_name = google_compute_instance_template.worker.name
-#   policy_data = data.google_iam_policy.logging.policy_data
-# }
-
-
-

--- a/deployment/gcp/gcp/iam.tf
+++ b/deployment/gcp/gcp/iam.tf
@@ -1,0 +1,97 @@
+### Service Account creation for Google Compute Instances
+resource "random_string" "boundary_controller" {
+  upper   = false
+  special = false
+  number  = false
+  length  = 16
+}
+
+resource "random_string" "boundary_worker" {
+  upper   = false
+  special = false
+  number  = false
+  length  = 16
+}
+
+resource "google_service_account" "boundary_controller" {
+  account_id   = random_string.boundary_controller.result
+  display_name = local.boundary_controller_name
+}
+
+
+resource "google_service_account" "boundary_worker" {
+  account_id   = random_string.boundary_worker.result
+  display_name = local.boundary_worker_name
+}
+
+
+### IAM for KMS access
+data "google_iam_policy" "kms" {
+  binding {
+    role = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+    members = [
+      "serviceAccount:${google_service_account.boundary_controller.email}",
+      "serviceAccount:${google_service_account.boundary_worker.email}"
+    ]
+  }
+}
+
+resource "google_kms_crypto_key_iam_policy" "root" {
+  crypto_key_id = google_kms_crypto_key.root.id
+  policy_data   = data.google_iam_policy.kms.policy_data
+}
+
+resource "google_kms_crypto_key_iam_policy" "worker_auth" {
+  crypto_key_id = google_kms_crypto_key.worker_auth.id
+  policy_data   = data.google_iam_policy.kms.policy_data
+}
+
+resource "google_kms_crypto_key_iam_policy" "recovery" {
+  crypto_key_id = google_kms_crypto_key.recovery.id
+  policy_data   = data.google_iam_policy.kms.policy_data
+}
+
+
+### IAM policy for certificate generation
+data "google_iam_policy" "cas" {
+  provider = google-beta
+  binding {
+    role = "roles/privateca.certificateManager"
+    members = [
+      "serviceAccount:${google_service_account.boundary_controller.email}",
+      "serviceAccount:${google_service_account.boundary_worker.email}"
+    ]
+  }
+}
+
+resource "google_privateca_certificate_authority_iam_policy" "cas" {
+  provider              = google-beta
+  certificate_authority = google_privateca_certificate_authority.this.id
+  policy_data           = data.google_iam_policy.cas.policy_data
+}
+
+### IAM for logging
+data "google_iam_policy" "logging" {
+  provider = google-beta
+  binding {
+    role = "roles/stackdriver.resourceMetadata.writer"
+    members = [
+      "serviceAccount:${google_service_account.boundary_controller.email}",
+      "serviceAccount:${google_service_account.boundary_worker.email}"
+    ]
+  }
+}
+
+# resource "google_compute_instance_iam_policy" "controller_logging" {
+#   instance_name = google_compute_instance_template.controller.name
+#   policy_data = data.google_iam_policy.logging.policy_data
+# }
+
+# resource "google_compute_instance_iam_policy" "worker_logging" {
+#   instance_name = google_compute_instance_template.worker.name
+#   policy_data = data.google_iam_policy.logging.policy_data
+# }
+
+
+

--- a/deployment/gcp/gcp/kms.tf
+++ b/deployment/gcp/gcp/kms.tf
@@ -1,0 +1,23 @@
+resource "google_kms_key_ring" "this" {
+  name     = local.boundary_name
+  location = "global"
+}
+
+resource "google_kms_crypto_key" "root" {
+  name            = local.boundary_root_key_name
+  key_ring        = google_kms_key_ring.this.id
+  rotation_period = var.kms_crypto_key_rotation_period
+}
+
+resource "google_kms_crypto_key" "worker_auth" {
+  name            = local.boundary_worker_auth_key_name
+  key_ring        = google_kms_key_ring.this.id
+  rotation_period = var.kms_crypto_key_rotation_period
+}
+
+resource "google_kms_crypto_key" "recovery" {
+  name            = local.boundary_recovery_key_name
+  key_ring        = google_kms_key_ring.this.id
+  rotation_period = var.kms_crypto_key_rotation_period
+}
+

--- a/deployment/gcp/gcp/lb.tf
+++ b/deployment/gcp/gcp/lb.tf
@@ -96,7 +96,7 @@ resource "google_compute_firewall" "cluster" {
   allow {
     protocol = "tcp"
     ports = [
-      var.controller_api_port
+      var.controller_cluster_port
     ]
   }
   log_config {
@@ -159,6 +159,7 @@ resource "google_compute_firewall" "health_checks" {
     ]
   }
   direction = "INGRESS"
+	target_tags = concat(var.boundary_controller_tags, var.boundary_worker_tags)
 }
 
 resource "google_compute_firewall" "worker" {

--- a/deployment/gcp/gcp/lb.tf
+++ b/deployment/gcp/gcp/lb.tf
@@ -1,0 +1,182 @@
+## Controller API load balancing
+resource "google_compute_address" "public_controller_api" {
+  name = local.boundary_controller_name
+}
+
+resource "google_compute_region_health_check" "controller_api" {
+  name               = local.boundary_controller_api_name
+  check_interval_sec = 1
+  timeout_sec        = 1
+  tcp_health_check {
+    port = var.controller_api_port
+  }
+}
+
+resource "google_compute_forwarding_rule" "controller_api" {
+  name            = local.boundary_controller_api_name
+  ip_address      = google_compute_address.public_controller_api.address
+  backend_service = google_compute_region_backend_service.controller_api.id
+  port_range      = var.controller_api_port
+  ip_protocol     = "TCP"
+}
+
+resource "google_compute_region_backend_service" "controller_api" {
+  name = local.boundary_controller_name
+  health_checks = [
+    google_compute_region_health_check.controller_api.id
+  ]
+  load_balancing_scheme = "EXTERNAL"
+  backend {
+    group          = google_compute_region_instance_group_manager.controller.instance_group
+    balancing_mode = "CONNECTION"
+  }
+}
+
+resource "google_compute_firewall" "api" {
+  name    = local.boundary_controller_api_name
+  network = google_compute_network.this.name
+
+  source_ranges = var.client_source_ranges
+
+  allow {
+    protocol = "tcp"
+    ports = [
+      var.controller_api_port
+    ]
+  }
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+  target_tags = var.boundary_controller_tags
+
+  direction = "INGRESS"
+}
+
+### Controller cluster load balancing
+resource "google_compute_address" "public_controller_cluster" {
+  name = local.boundary_controller_cluster_name
+}
+
+resource "google_compute_region_health_check" "controller_cluster" {
+  name               = local.boundary_controller_cluster_name
+  check_interval_sec = 1
+  timeout_sec        = 1
+  tcp_health_check {
+    port = var.controller_cluster_port
+  }
+}
+
+resource "google_compute_forwarding_rule" "controller_cluster" {
+  name            = local.boundary_controller_cluster_name
+  ip_address      = google_compute_address.public_controller_cluster.address
+  backend_service = google_compute_region_backend_service.controller_cluster.id
+  port_range      = var.controller_cluster_port
+  ip_protocol     = "TCP"
+}
+
+resource "google_compute_region_backend_service" "controller_cluster" {
+  name = local.boundary_controller_cluster_name
+  health_checks = [
+    google_compute_region_health_check.controller_cluster.id
+  ]
+  load_balancing_scheme = "EXTERNAL"
+  backend {
+    group          = google_compute_region_instance_group_manager.controller.instance_group
+    balancing_mode = "CONNECTION"
+  }
+}
+
+resource "google_compute_firewall" "cluster" {
+  name    = local.boundary_controller_cluster_name
+  network = google_compute_network.this.name
+
+  source_tags   = var.boundary_worker_tags
+  source_ranges = var.worker_source_ranges != [] ? var.worker_source_ranges : null
+
+  allow {
+    protocol = "tcp"
+    ports = [
+      var.controller_api_port
+    ]
+  }
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+  target_tags = var.boundary_controller_tags
+
+  direction = "INGRESS"
+}
+
+### Worker load balancing
+resource "google_compute_address" "public_worker" {
+  name = local.boundary_worker_name
+}
+
+resource "google_compute_forwarding_rule" "worker" {
+  name            = local.boundary_worker_name
+  backend_service = google_compute_region_backend_service.worker.id
+  port_range      = var.worker_port
+  ip_address      = google_compute_address.public_worker.address
+}
+
+resource "google_compute_region_backend_service" "worker" {
+  name                  = local.boundary_worker_name
+  load_balancing_scheme = "EXTERNAL"
+  health_checks = [
+    google_compute_region_health_check.worker.id
+  ]
+  backend {
+    group          = google_compute_region_instance_group_manager.worker.instance_group
+    balancing_mode = "CONNECTION"
+  }
+}
+
+resource "google_compute_region_health_check" "worker" {
+  name               = local.boundary_worker_name
+  check_interval_sec = 1
+  timeout_sec        = 1
+  http_health_check {
+    port = var.worker_port
+  }
+}
+
+resource "google_compute_firewall" "health_checks" {
+  name    = "${local.boundary_name}-health-checks"
+  network = google_compute_network.this.name
+
+  source_ranges = [
+    "35.191.0.0/16",
+    "209.85.152.0/22",
+    "209.85.204.0/22"
+  ]
+
+  allow {
+    protocol = "tcp"
+    ports = [
+      var.controller_api_port,
+      var.controller_cluster_port,
+      var.worker_port
+    ]
+  }
+  direction = "INGRESS"
+}
+
+resource "google_compute_firewall" "worker" {
+  name    = local.boundary_worker_name
+  network = google_compute_network.this.name
+
+  source_ranges = var.client_source_ranges
+
+  allow {
+    protocol = "tcp"
+    ports = [
+      var.worker_port
+    ]
+  }
+  log_config {
+    metadata = "INCLUDE_ALL_METADATA"
+  }
+  target_tags = var.boundary_worker_tags
+
+  direction = "INGRESS"
+}

--- a/deployment/gcp/gcp/main.tf
+++ b/deployment/gcp/gcp/main.tf
@@ -1,0 +1,30 @@
+## We use this to append a unique id on the end of our names to prevent collisions.
+resource "random_id" "this" {
+  byte_length = 8
+}
+
+data "google_compute_zones" "this" {
+}
+
+## We are using locals here for a couple of purposes. The first is to render
+## out our config file. We do this once with a number of conditions so that we
+## only have to maintain the inputs in one place, and then apply it to both
+## our workers and controllers.
+## The second purpose is to have somewhere you can easily update your naming
+## conventions should you choose to do so.
+
+locals {
+  boundary_name = "boundary-${random_id.this.hex}"
+
+  boundary_controller_name         = "${local.boundary_name}-controller"
+  boundary_controller_api_name     = "${local.boundary_name}-controller-api"
+  boundary_controller_cluster_name = "${local.boundary_name}-controller-cluster"
+
+  boundary_worker_name = "${local.boundary_name}-worker"
+
+  boundary_root_key_name        = "${local.boundary_name}-root"
+  boundary_worker_auth_key_name = "${local.boundary_name}-worker-auth"
+  boundary_recovery_key_name    = "${local.boundary_name}-recovery"
+
+  ssh_key_string = var.ssh_key_path != "" ? "${var.ssh_username}:${file(var.ssh_key_path)}" : null
+}

--- a/deployment/gcp/gcp/outputs.tf
+++ b/deployment/gcp/gcp/outputs.tf
@@ -1,9 +1,5 @@
-output boundary_api_public_ip {
-  value = google_compute_address.public_controller_api.address
-}
-
-output boundary_api_port {
-  value = var.controller_api_port
+output boundary_url {
+	value = var.tls_disabled == false ? "https://${google_compute_address.public_controller_api.address}:${var.controller_api_port}" : "http://${google_compute_address.public_controller_api.address}:${var.controller_api_port}"
 }
 
 output boundary_api_controller {
@@ -24,4 +20,8 @@ output crypto_ring {
 
 output gcp_project {
 	value = var.project
+}
+
+output target_ip {
+	value = var.enable_target == 0 ? null : google_compute_instance.this[0].network_interface[0].network_ip
 }

--- a/deployment/gcp/gcp/outputs.tf
+++ b/deployment/gcp/gcp/outputs.tf
@@ -23,5 +23,5 @@ output gcp_project {
 }
 
 output target_ip {
-	value = var.enable_target == 0 ? null : google_compute_instance.this[0].network_interface[0].network_ip
+	value = var.enable_target == 0 ? "Target not deployed, no valid IP address." : [ google_compute_instance.this[0].network_interface[0].network_ip ]
 }

--- a/deployment/gcp/gcp/outputs.tf
+++ b/deployment/gcp/gcp/outputs.tf
@@ -23,5 +23,5 @@ output gcp_project {
 }
 
 output target_ip {
-	value = var.enable_target == 0 ? "Target not deployed, no valid IP address." : [ google_compute_instance.this[0].network_interface[0].network_ip ]
+	value = var.enable_target == 0 ? "Target not deployed, no valid IP address." : google_compute_instance.this[0].network_interface[0].network_ip
 }

--- a/deployment/gcp/gcp/outputs.tf
+++ b/deployment/gcp/gcp/outputs.tf
@@ -1,0 +1,27 @@
+output boundary_api_public_ip {
+  value = google_compute_address.public_controller_api.address
+}
+
+output boundary_api_port {
+  value = var.controller_api_port
+}
+
+output boundary_api_controller {
+  value = google_compute_address.public_controller_cluster.address
+}
+
+output boundary_controller_port {
+  value = var.controller_cluster_port
+}
+
+output recovery_key {
+	value = google_kms_crypto_key.recovery.name
+}
+
+output crypto_ring {
+	value = google_kms_key_ring.this.name
+}
+
+output gcp_project {
+	value = var.project
+}

--- a/deployment/gcp/gcp/pki.tf
+++ b/deployment/gcp/gcp/pki.tf
@@ -23,7 +23,6 @@ resource "google_privateca_certificate_authority" "this" {
   key_spec {
     algorithm = "RSA_PKCS1_4096_SHA256"
   }
-  disable_on_delete = true
 }
 
 ## Check iam.tf for IAM priveleges related to certificate generation

--- a/deployment/gcp/gcp/pki.tf
+++ b/deployment/gcp/gcp/pki.tf
@@ -1,0 +1,29 @@
+resource "google_privateca_certificate_authority" "this" {
+  provider                 = google-beta
+  location                 = var.ca_issuer_location
+  project                  = var.project
+  certificate_authority_id = local.boundary_name
+  config {
+    subject_config {
+      subject {
+        organization = var.ca_organization
+      }
+      common_name = var.ca_common_name
+      dynamic "subject_alt_name" {
+        for_each = var.ca_subject_alternate_names
+        content {
+          dns_names = each.value
+        }
+      }
+    }
+    reusable_config {
+      reusable_config = "root-unconstrained"
+    }
+  }
+  key_spec {
+    algorithm = "RSA_PKCS1_4096_SHA256"
+  }
+  disable_on_delete = true
+}
+
+## Check iam.tf for IAM priveleges related to certificate generation

--- a/deployment/gcp/gcp/pki.tf
+++ b/deployment/gcp/gcp/pki.tf
@@ -1,4 +1,5 @@
 resource "google_privateca_certificate_authority" "this" {
+	count = var.tls_disabled == true ? 0 : 1
   provider                 = google-beta
   location                 = var.ca_issuer_location
   project                  = var.project

--- a/deployment/gcp/gcp/target.tf
+++ b/deployment/gcp/gcp/target.tf
@@ -1,0 +1,49 @@
+resource "random_shuffle" "this" {
+	count = var.enable_target == 0 ? 0 : 1
+  input = data.google_compute_zones.this.names
+  result_count = 1
+}
+
+resource "google_compute_instance" "this" {
+	count = var.enable_target == 0 ? 0 : 1
+  name         = "${local.boundary_name}-target"
+	zone = random_shuffle.this[0].result[0]
+  machine_type = var.compute_machine_type
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.this.id
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.worker.id
+  }
+
+	tags = [ "boundary-target" ]
+
+  metadata = {
+    ssh-keys = local.ssh_key_string
+  }
+}
+
+resource "google_compute_firewall" "target" {
+	count = var.enable_target == 0 ? 0 : 1
+  name    = "${local.boundary_name}-target"
+  network = google_compute_network.this.name
+
+  source_tags = var.boundary_worker_tags
+
+  allow {
+    protocol = "tcp"
+    ports = [
+      22
+    ]
+  }
+
+  target_tags = ["boundary-target"]
+
+  direction = "INGRESS"
+}
+
+

--- a/deployment/gcp/gcp/templates/boundary.hcl.tpl
+++ b/deployment/gcp/gcp/templates/boundary.hcl.tpl
@@ -34,6 +34,7 @@ sudo chown boundary:boundary /usr/bin/boundary
 %{ if type == "controller" }
 gcloud beta privateca certificates create \
   --issuer ${ca_name} \
+	--subject $hostname
 	--issuer-location ${ca_issuer_location} \
   --generate-key \
   --key-output-file ${tls_key_path}/api.key \
@@ -43,6 +44,7 @@ gcloud beta privateca certificates create \
 
 gcloud beta privateca certificates create \
   --issuer ${ca_name} \
+	--subject $hostname
 	--issuer-location ${ca_issuer_location} \
   --generate-key \
   --key-output-file ${tls_key_path}/controller.key \
@@ -130,6 +132,7 @@ EOF
 %{ if type == "worker" }
 gcloud beta privateca certificates create \
   --issuer ${ca_name} \
+	--subject $hostname
 	--issuer-location ${ca_issuer_location} \
   --generate-key \
   --key-output-file ${tls_key_path}/worker.key \

--- a/deployment/gcp/gcp/templates/boundary.hcl.tpl
+++ b/deployment/gcp/gcp/templates/boundary.hcl.tpl
@@ -1,0 +1,225 @@
+#!/bin/bash
+
+private_ip=$(hostname -i | awk '{print $1}')
+hostname=$(hostname)
+
+# Install official HashiCorp Repository and install Boundary
+sudo apt-get update
+sudo apt-get install curl -y
+curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+%{ if boundary_version != "" }
+sudo apt-get update && sudo apt-get install boundary=${boundary_version} -y
+%{ else }
+sudo apt-get update && sudo apt-get install boundary -y
+%{ endif }
+
+
+# Create boundary directories
+mkdir /etc/boundary.d
+mkdir /etc/boundary.d/tls
+
+# Install cryptography module so we can request auto-generated certs from Google CAS
+sudo apt-get install python-pip -y
+pip install --user "cryptography>=2.2.0"
+export CLOUDSDK_PYTHON=python
+export CLOUDSDK_PYTHON_SITEPACKAGES=1
+
+# Add the boundary system user and group to ensure we have a no-login
+# user capable of owning and running Boundary
+sudo adduser --system --group boundary || true
+sudo chown boundary:boundary /etc/boundary.d/boundary-${type}.hcl
+sudo chown boundary:boundary /usr/bin/boundary
+
+%{ if type == "controller" }
+gcloud beta privateca certificates create \
+  --issuer ${ca_name} \
+	--issuer-location ${ca_issuer_location} \
+  --generate-key \
+  --key-output-file ${tls_key_path}/api.key \
+  --cert-output-file ${tls_cert_path}/api.crt \
+  --ip-san ${controller_api_listener_ip} \
+  --reusable-config "leaf-server-tls"
+
+gcloud beta privateca certificates create \
+  --issuer ${ca_name} \
+	--issuer-location ${ca_issuer_location} \
+  --generate-key \
+  --key-output-file ${tls_key_path}/controller.key \
+  --cert-output-file ${tls_cert_path}/controller.crt \
+  --ip-san ${controller_cluster_listener_ip} \
+  --reusable-config "leaf-server-tls"
+export CLOUDSDK_PYTHON_SITEPACKAGES=0
+
+# Take ownership of certificates
+sudo chown boundary:boundary /etc/boundary.d/tls/api.crt
+sudo chown boundary:boundary /etc/boundary.d/tls/api.key
+sudo chown boundary:boundary /etc/boundary.d/tls/controller.crt
+sudo chown boundary:boundary /etc/boundary.d/tls/controller.key
+
+cat <<EOF > /etc/boundary.d/boundary-controller.hcl
+disable_mlock = true
+
+telemetry {
+  prometheus_retention_time = "24h"
+  disable_hostname          = true
+}
+
+controller {
+  name        = "$hostname"
+  description = "A controller for a demo!"
+
+  database {
+    url = "postgresql://${db_username}:${db_password}@${db_endpoint}/${db_name}"
+  }
+	public_cluster_addr = "${public_cluster_address}"
+}
+
+listener "tcp" {
+  address                           = "${controller_api_listener_ip}:${controller_api_port}"
+	purpose                           = "api"
+%{ if tls_disabled == true }
+	tls_disable                       = true
+%{ else }
+  tls_disable   = false
+  tls_cert_file = "${tls_cert_path}/api.crt"
+  tls_key_file  = "${tls_key_path}/api.key"
+%{ endif }
+	cors_enabled                      = true
+	cors_allowed_origins              = ["*"]
+}
+
+listener "tcp" {
+  address                           = "${controller_cluster_listener_ip}:${controller_cluster_port}"
+	purpose                           = "cluster"
+%{ if tls_disabled == true }
+	tls_disable                       = true
+%{ else }
+  tls_disable   = false
+  tls_cert_file = "${tls_cert_path}/controller.crt"
+  tls_key_file  = "${tls_key_path}/controller.key"
+%{ endif }
+}
+
+kms "gcpckms" {
+  purpose     = "root"
+  key_ring    = "${kms_key_ring}"
+  crypto_key  = "${kms_root_key_id}"
+	project     = "${project_id}"
+	region      = "global"
+}
+
+kms "gcpckms" {
+  purpose     = "worker-auth"
+  key_ring    = "${kms_key_ring}"
+  crypto_key  = "${kms_worker_auth_key_id}"
+	project     = "${project_id}"
+	region      = "global"
+}
+
+kms "gcpckms" {
+  purpose     = "recovery"
+  key_ring    = "${kms_key_ring}"
+  crypto_key  = "${kms_recovery_key_id}"
+	project     = "${project_id}"
+	region      = "global"
+}
+EOF
+%{ endif }
+
+%{ if type == "worker" }
+gcloud beta privateca certificates create \
+  --issuer ${ca_name} \
+	--issuer-location ${ca_issuer_location} \
+  --generate-key \
+  --key-output-file ${tls_key_path}/worker.key \
+  --cert-output-file ${tls_cert_path}/worker.crt \
+  --ip-san ${worker_listener_ip} \
+  --reusable-config "leaf-server-tls"
+export CLOUDSDK_PYTHON_SITEPACKAGES=0
+
+# Take ownership of certificates
+sudo chown boundary:boundary /etc/boundary.d/tls/worker.crt
+sudo chown boundary:boundary /etc/boundary.d/tls/worker.key
+
+cat <<EOF > /etc/boundary.d/boundary-worker.hcl
+
+listener "tcp" {
+  address = "${worker_listener_ip}:${worker_port}"
+	purpose = "proxy"
+%{ if tls_disabled == true }
+	tls_disable = true
+%{ else }
+  tls_disable   = false
+  tls_cert_file = "${tls_cert_path}/worker.crt"
+  tls_key_file  = "${tls_key_path}/worker.key"
+%{ endif }
+
+}
+
+worker {
+	public_addr = "${public_worker_address}"
+	name = "$hostname"
+	controllers = [
+		"${public_cluster_address}"
+  ]
+}
+
+kms "gcpckms" {
+  purpose     = "root"
+  key_ring    = "${kms_key_ring}"
+  crypto_key  = "${kms_root_key_id}"
+	project     = "${project_id}"
+	region      = "global"
+}
+
+kms "gcpckms" {
+  purpose     = "worker-auth"
+  key_ring    = "${kms_key_ring}"
+  crypto_key  = "${kms_worker_auth_key_id}"
+	project     = "${project_id}"
+	region      = "global"
+}
+
+kms "gcpckms" {
+  purpose     = "recovery"
+  key_ring    = "${kms_key_ring}"
+  crypto_key  = "${kms_recovery_key_id}"
+	project     = "${project_id}"
+	region      = "global"
+}
+EOF
+%{ endif }
+
+# Install the boundary as a service for systemd on linux
+
+sudo cat << EOF > /etc/systemd/system/boundary-${type}.service
+[Unit]
+Description=boundary ${type}
+
+[Service]
+ExecStart=/usr/bin/boundary server -config /etc/boundary.d/boundary-${type}.hcl
+User=boundary
+Group=boundary
+LimitMEMLOCK=infinity
+Capabilities=CAP_IPC_LOCK+ep
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Make sure to initialize the DB before starting the service. This will result in
+# a database already initizalized warning if another controller or worker has done this 
+# already, making it a lazy, best effort initialization
+if [ "${type}" = "controller" ]; then
+  boundary database init -skip-auth-method-creation -skip-host-resources-creation -skip-scopes-creation -skip-target-creation -config /etc/boundary.d/boundary-${type}.hcl || true
+fi
+
+# Finish service configuration for boundary and start the service
+sudo chmod 664 /etc/systemd/system/boundary-${type}.service
+sudo systemctl daemon-reload
+sudo systemctl enable boundary-${type}
+sudo systemctl start boundary-${type}
+
+

--- a/deployment/gcp/gcp/templates/boundary.hcl.tpl
+++ b/deployment/gcp/gcp/templates/boundary.hcl.tpl
@@ -1,6 +1,4 @@
 #!/bin/bash
-
-private_ip=$(hostname -i | awk '{print $1}')
 hostname=$(hostname)
 
 # Install official HashiCorp Repository and install Boundary
@@ -28,13 +26,11 @@ export CLOUDSDK_PYTHON_SITEPACKAGES=1
 # Add the boundary system user and group to ensure we have a no-login
 # user capable of owning and running Boundary
 sudo adduser --system --group boundary || true
-sudo chown boundary:boundary /etc/boundary.d/boundary-${type}.hcl
 sudo chown boundary:boundary /usr/bin/boundary
 
 %{ if type == "controller" }
 gcloud beta privateca certificates create \
   --issuer ${ca_name} \
-	--subject $hostname
 	--issuer-location ${ca_issuer_location} \
   --generate-key \
   --key-output-file ${tls_key_path}/api.key \
@@ -44,7 +40,6 @@ gcloud beta privateca certificates create \
 
 gcloud beta privateca certificates create \
   --issuer ${ca_name} \
-	--subject $hostname
 	--issuer-location ${ca_issuer_location} \
   --generate-key \
   --key-output-file ${tls_key_path}/controller.key \
@@ -132,7 +127,6 @@ EOF
 %{ if type == "worker" }
 gcloud beta privateca certificates create \
   --issuer ${ca_name} \
-	--subject $hostname
 	--issuer-location ${ca_issuer_location} \
   --generate-key \
   --key-output-file ${tls_key_path}/worker.key \
@@ -220,6 +214,7 @@ if [ "${type}" = "controller" ]; then
 fi
 
 # Finish service configuration for boundary and start the service
+sudo chown boundary:boundary /etc/boundary.d/boundary-${type}.hcl
 sudo chmod 664 /etc/systemd/system/boundary-${type}.service
 sudo systemctl daemon-reload
 sudo systemctl enable boundary-${type}

--- a/deployment/gcp/gcp/templates/controller.hcl.tpl
+++ b/deployment/gcp/gcp/templates/controller.hcl.tpl
@@ -1,0 +1,157 @@
+#!/bin/bash
+hostname=$(hostname)
+
+# Install official HashiCorp Repository and install Boundary
+sudo apt-get update
+sudo apt-get install curl -y
+curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+%{ if boundary_version != "" }
+sudo apt-get update && sudo apt-get install boundary=${boundary_version} -y
+%{ else }
+sudo apt-get update && sudo apt-get install boundary -y
+%{ endif }
+
+
+# Create boundary directories
+mkdir /etc/boundary.d
+
+# Add the boundary system user and group to ensure we have a no-login
+# user capable of owning and running Boundary
+sudo adduser --system --group boundary || true
+sudo chown boundary:boundary /usr/bin/boundary
+
+%{ if tls_disabled == false }
+# Install cryptography module so we can request auto-generated certs from Google CAS
+sudo apt-get install python-pip -y
+mkdir /etc/boundary.d/tls
+pip install --user "cryptography>=2.2.0"
+export CLOUDSDK_PYTHON=python
+export CLOUDSDK_PYTHON_SITEPACKAGES=1
+
+gcloud beta privateca certificates create \
+  --issuer ${ca_name} \
+	--issuer-location ${ca_issuer_location} \
+  --generate-key \
+  --key-output-file ${tls_key_path}/api.key \
+  --cert-output-file ${tls_cert_path}/api.crt \
+  --ip-san ${controller_api_listener_ip} \
+  --reusable-config "leaf-server-tls"
+
+gcloud beta privateca certificates create \
+  --issuer ${ca_name} \
+	--issuer-location ${ca_issuer_location} \
+  --generate-key \
+  --key-output-file ${tls_key_path}/controller.key \
+  --cert-output-file ${tls_cert_path}/controller.crt \
+  --ip-san ${controller_cluster_listener_ip} \
+  --reusable-config "leaf-server-tls"
+export CLOUDSDK_PYTHON_SITEPACKAGES=0
+
+# Take ownership of certificates
+sudo chown boundary:boundary /etc/boundary.d/tls/api.crt
+sudo chown boundary:boundary /etc/boundary.d/tls/api.key
+sudo chown boundary:boundary /etc/boundary.d/tls/controller.crt
+sudo chown boundary:boundary /etc/boundary.d/tls/controller.key
+%{ endif }
+
+#Generate config file
+cat <<EOF > /etc/boundary.d/boundary-controller.hcl
+disable_mlock = true
+
+telemetry {
+  prometheus_retention_time = "24h"
+  disable_hostname          = true
+}
+
+controller {
+  name        = "$hostname"
+  description = "A controller for a demo!"
+
+  database {
+    url = "postgresql://${db_username}:${db_password}@${db_endpoint}/${db_name}"
+  }
+	public_cluster_addr = "${public_cluster_address}"
+}
+
+listener "tcp" {
+  address                           = "${controller_api_listener_ip}:${controller_api_port}"
+	purpose                           = "api"
+%{ if tls_disabled == true }
+	tls_disable                       = true
+%{ else }
+  tls_disable   = false
+  tls_cert_file = "${tls_cert_path}/api.crt"
+  tls_key_file  = "${tls_key_path}/api.key"
+%{ endif }
+	cors_enabled                      = true
+	cors_allowed_origins              = ["*"]
+}
+
+listener "tcp" {
+  address                           = "${controller_cluster_listener_ip}:${controller_cluster_port}"
+	purpose                           = "cluster"
+%{ if tls_disabled == true }
+	tls_disable                       = true
+%{ else }
+  tls_disable   = false
+  tls_cert_file = "${tls_cert_path}/controller.crt"
+  tls_key_file  = "${tls_key_path}/controller.key"
+%{ endif }
+}
+
+kms "gcpckms" {
+  purpose     = "root"
+  key_ring    = "${kms_key_ring}"
+  crypto_key  = "${kms_root_key_id}"
+	project     = "${project_id}"
+	region      = "global"
+}
+
+kms "gcpckms" {
+  purpose     = "worker-auth"
+  key_ring    = "${kms_key_ring}"
+  crypto_key  = "${kms_worker_auth_key_id}"
+	project     = "${project_id}"
+	region      = "global"
+}
+
+kms "gcpckms" {
+  purpose     = "recovery"
+  key_ring    = "${kms_key_ring}"
+  crypto_key  = "${kms_recovery_key_id}"
+	project     = "${project_id}"
+	region      = "global"
+}
+EOF
+
+# Install the boundary as a service for systemd on linux
+
+sudo cat << EOF > /etc/systemd/system/boundary-controller.service
+[Unit]
+Description=boundary controller
+
+[Service]
+ExecStart=/usr/bin/boundary server -config /etc/boundary.d/boundary-controller.hcl
+User=boundary
+Group=boundary
+LimitMEMLOCK=infinity
+Capabilities=CAP_IPC_LOCK+ep
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Make sure to initialize the DB before starting the service. This will result in
+# a database already initizalized warning if another controller or worker has done this 
+# already, making it a lazy, best effort initialization
+boundary database init -skip-auth-method-creation -skip-host-resources-creation -skip-scopes-creation -skip-target-creation -config /etc/boundary.d/boundary-controller.hcl || true
+
+
+# Finish service configuration for boundary and start the service
+sudo chown boundary:boundary /etc/boundary.d/boundary-controller.hcl
+sudo chmod 664 /etc/systemd/system/boundary-controller.service
+sudo systemctl daemon-reload
+sudo systemctl enable boundary-controller
+sudo systemctl start boundary-controller

--- a/deployment/gcp/gcp/templates/worker.hcl.tpl
+++ b/deployment/gcp/gcp/templates/worker.hcl.tpl
@@ -1,0 +1,119 @@
+#!/bin/bash
+hostname=$(hostname)
+
+# Install official HashiCorp Repository and install Boundary
+sudo apt-get update
+sudo apt-get install curl -y
+curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+%{ if boundary_version != "" }
+sudo apt-get update && sudo apt-get install boundary=${boundary_version} -y
+%{ else }
+sudo apt-get update && sudo apt-get install boundary -y
+%{ endif }
+
+
+# Create boundary directory
+mkdir /etc/boundary.d
+
+# Add the boundary system user and group to ensure we have a no-login
+# user capable of owning and running Boundary
+sudo adduser --system --group boundary || true
+sudo chown boundary:boundary /usr/bin/boundary
+
+%{ if tls_disabled == false }
+# Install cryptography module so we can request auto-generated certs from Google CAS
+sudo apt-get install python-pip -y
+mkdir /etc/boundary.d/tls
+pip install --user "cryptography>=2.2.0"
+export CLOUDSDK_PYTHON=python
+export CLOUDSDK_PYTHON_SITEPACKAGES=1
+
+gcloud beta privateca certificates create \
+  --issuer ${ca_name} \
+	--issuer-location ${ca_issuer_location} \
+  --generate-key \
+  --key-output-file ${tls_key_path}/worker.key \
+  --cert-output-file ${tls_cert_path}/worker.crt \
+  --ip-san ${worker_listener_ip} \
+  --reusable-config "leaf-server-tls"
+export CLOUDSDK_PYTHON_SITEPACKAGES=0
+
+# Take ownership of certificates
+sudo chown boundary:boundary /etc/boundary.d/tls/worker.crt
+sudo chown boundary:boundary /etc/boundary.d/tls/worker.key
+%{ endif }
+
+# Generate config file
+cat <<EOF > /etc/boundary.d/boundary-worker.hcl
+
+listener "tcp" {
+  address = "${worker_listener_ip}:${worker_port}"
+	purpose = "proxy"
+%{ if tls_disabled == true }
+	tls_disable = true
+%{ else }
+  tls_disable   = false
+  tls_cert_file = "${tls_cert_path}/worker.crt"
+  tls_key_file  = "${tls_key_path}/worker.key"
+%{ endif }
+
+}
+
+worker {
+	public_addr = "${public_worker_address}"
+	name = "$hostname"
+	controllers = [
+		"${public_cluster_address}"
+  ]
+}
+
+kms "gcpckms" {
+  purpose     = "root"
+  key_ring    = "${kms_key_ring}"
+  crypto_key  = "${kms_root_key_id}"
+	project     = "${project_id}"
+	region      = "global"
+}
+
+kms "gcpckms" {
+  purpose     = "worker-auth"
+  key_ring    = "${kms_key_ring}"
+  crypto_key  = "${kms_worker_auth_key_id}"
+	project     = "${project_id}"
+	region      = "global"
+}
+
+kms "gcpckms" {
+  purpose     = "recovery"
+  key_ring    = "${kms_key_ring}"
+  crypto_key  = "${kms_recovery_key_id}"
+	project     = "${project_id}"
+	region      = "global"
+}
+EOF
+
+# Install the boundary as a service for systemd on linux
+
+sudo cat << EOF > /etc/systemd/system/boundary-worker.service
+[Unit]
+Description=boundary worker
+
+[Service]
+ExecStart=/usr/bin/boundary server -config /etc/boundary.d/boundary-worker.hcl
+User=boundary
+Group=boundary
+LimitMEMLOCK=infinity
+Capabilities=CAP_IPC_LOCK+ep
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Finish service configuration for boundary and start the service
+sudo chown boundary:boundary /etc/boundary.d/boundary-worker.hcl
+sudo chmod 664 /etc/systemd/system/boundary-worker.service
+sudo systemctl daemon-reload
+sudo systemctl enable boundary-worker
+sudo systemctl start boundary-worker

--- a/deployment/gcp/gcp/variables.tf
+++ b/deployment/gcp/gcp/variables.tf
@@ -155,18 +155,6 @@ variable "boundary_worker_tags" {
   ]
 }
 
-variable "ssh_username" {
-  type        = string
-  description = "The name of the user which you want to set the SSH public certificate for."
-  default     = "ubuntu"
-}
-
-variable "ssh_key_path" {
-  type        = string
-  description = "The absolute path to the public certificate of your SSH key."
-  default     = ""
-}
-
 # Boundary listener variables
 variable "controller_api_port" {
   type        = number
@@ -226,3 +214,21 @@ variable "my_public_ip" {
   default = ""
 }
 
+variable "ssh_username" {
+  type        = string
+  description = "The name of the user which you want to set the SSH public certificate for."
+  default     = "ubuntu"
+}
+
+variable "ssh_key_path" {
+  type        = string
+  description = "The absolute path to the public certificate of your SSH key."
+  default     = ""
+}
+
+#Enable or disable an example target machine.
+variable "enable_target" {
+	type = bool
+	description = "Use to toggle creating a compute instance that can be used as a target for Boundary. Note that to connect you will also need to configure the ssh_key_path variable."
+	default = true
+}

--- a/deployment/gcp/gcp/variables.tf
+++ b/deployment/gcp/gcp/variables.tf
@@ -1,0 +1,228 @@
+# Google Cloud provider variables
+variable "project" {
+  default = "go-gcp-demos"
+}
+
+variable "location" {
+  default = "australia-southeast1"
+}
+
+# Boundary binary variables
+variable "boundary_version" {
+  type        = string
+  description = "Leaving this blank defaults to pull down the latest binary."
+  default     = ""
+}
+
+# Boundary networking variables
+variable "vpc_subnet" {
+  type        = string
+  description = "The CIDR used by your VPC subnet. This will be peered with the GCP managed VPC for CloudSQL, which requires a minimum of a /24."
+  default     = "192.168.10.0/24"
+}
+
+variable "controller_subnet" {
+  type        = string
+  description = "Optional variable that configures the subnetwork CIDR. By default this will be calculated as a function of the VPC CIDR."
+  default     = ""
+}
+
+variable "worker_subnet" {
+  type        = string
+  description = "Optional variable that configures the subnetwork CIDR. By default this will be calculated as a function of the VPC CIDR."
+  default     = ""
+}
+
+variable "client_source_ranges" {
+  type        = list
+  description = "The source CIDR ranges that should be able to access Boundary."
+  default = [
+    "0.0.0.0/0"
+  ]
+}
+
+variable "worker_source_ranges" {
+  type        = list
+  description = "A range of IPs/CIDRs for workers NOT deployed with this module that should be able to register with the Boundary controller."
+  default     = []
+}
+
+# Boundary KMS variables
+variable "kms_crypto_key_rotation_period" {
+  type        = string
+  description = "The number of seconds after which your keys will be rotated."
+  default     = "100000s"
+}
+
+
+# Boundary database variables
+variable "boundary_database_name" {
+  type        = string
+  description = "The name used when creating your Boundary database."
+  default     = "boundary"
+}
+
+variable "boundary_database_username" {
+  type        = string
+  description = "The username that will be created and used for controller connection to your database."
+  default     = "boundary"
+}
+
+variable "boundary_database_password" {
+  type        = string
+  description = "The password that will be created and used for controller connection to your database."
+  default     = "boundary"
+}
+
+variable "postgres_version" {
+  type        = string
+  description = "Postgres version to be used. Boundary has only been tested with 12+."
+  default     = "POSTGRES_12"
+}
+
+variable "database_tier" {
+  type        = string
+  description = "The instance size for CloudSQL"
+  default     = "db-f1-micro"
+}
+
+# Boundary compute variables
+variable "compute_image_family" {
+  type        = string
+  description = "The name of the family which you source your image from. This module leverages apt for software installation, so your choice should be a debian based distro."
+  default     = "ubuntu-1804-lts"
+}
+
+variable "compute_image_project" {
+  type        = string
+  description = "The name of the family which you source your image from. This module leverages apt for software installation, so your choice should be a debian based project."
+  default     = "ubuntu-os-cloud"
+}
+
+variable "compute_machine_type" {
+  type        = string
+  description = "The size of the controller and worker nodes that will be created."
+  default     = "e2-medium"
+}
+
+variable "max_worker_replicas" {
+  type        = number
+  description = "The maximum number of nodes in the worker autoscaling group."
+  default     = 5
+}
+variable "min_worker_replicas" {
+  type        = number
+  description = "The minimum number of nodes in the worker autoscaling group."
+  default     = 2
+}
+
+variable "max_controller_replicas" {
+  type        = number
+  description = "The maximum number of nodes in the autoscaling group."
+  default     = 5
+}
+variable "min_controller_replicas" {
+  type        = number
+  description = "The minimum number of nodes in the controller autoscaling group."
+  default     = 2
+}
+
+variable "controller_instance_can_ip_forward" {
+  type        = bool
+  description = "Determines whether the instance can perform IP forwarding."
+  default     = false
+}
+
+variable "worker_instance_can_ip_forward" {
+  type        = bool
+  description = "Determines whether the instance can perform IP forwarding."
+  default     = false
+}
+
+variable "boundary_controller_tags" {
+  type        = list
+  description = "A set of tags that are applied to your controllers. Used with security groups."
+  default = [
+    "boundary-controller"
+  ]
+}
+
+variable "boundary_worker_tags" {
+  type        = list
+  description = "A set of tags that are applied to your workers. Used with security groups."
+  default = [
+    "boundary-worker"
+  ]
+}
+
+variable "ssh_username" {
+  type        = string
+  description = "The name of the user which you want to set the SSH public certificate for."
+  default     = "ubuntu"
+}
+
+variable "ssh_key_path" {
+  type        = string
+  description = "The absolute path to the public certificate of your SSH key."
+  default     = ""
+}
+
+# Boundary listener variables
+variable "controller_api_port" {
+  type        = number
+  description = "The port on which the controller api service will listen."
+  default     = 9200
+}
+
+variable "controller_cluster_port" {
+  type        = number
+  description = "The port on which the controller cluster service will listen."
+  default     = 9201
+}
+
+variable "worker_port" {
+  type        = number
+  description = "The port on which the worker service will listen."
+  default     = 9202
+}
+
+# Boundary PKI Variables
+variable ca_organization {
+  default = "HashiCorp"
+}
+
+variable ca_common_name {
+  default = "boundary.local"
+}
+
+variable ca_subject_alternate_names {
+  default = []
+}
+
+variable "tls_disabled" {
+  default = false
+}
+
+variable "tls_cert_path" {
+  default = "/etc/boundary.d/tls"
+}
+
+variable "tls_key_path" {
+  default = "/etc/boundary.d/tls"
+}
+
+variable "ca_issuer_location" {
+	type = string
+	description = ""
+	default = "asia-east1"
+}
+
+# Debugging variables
+variable "enable_ssh" {
+  default = false
+}
+
+variable "my_public_ip" {
+  default = ""
+}
+

--- a/deployment/gcp/gcp/vpc.tf
+++ b/deployment/gcp/gcp/vpc.tf
@@ -1,0 +1,32 @@
+resource "google_compute_network" "this" {
+  name                    = local.boundary_name
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "controller" {
+  name          = local.boundary_controller_name
+  ip_cidr_range = var.controller_subnet == "" ? cidrsubnet(var.vpc_subnet, 4, 0) : var.controller_subnet
+  network       = google_compute_network.this.id
+}
+
+resource "google_compute_subnetwork" "worker" {
+  name          = local.boundary_worker_name
+  ip_cidr_range = var.worker_subnet == "" ? cidrsubnet(var.vpc_subnet, 4, 1) : var.worker_subnet
+  network       = google_compute_network.this.id
+}
+
+resource "google_compute_global_address" "this" {
+  name          = local.boundary_name
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 24
+  network       = google_compute_network.this.id
+}
+
+resource "google_service_networking_connection" "this" {
+  network = google_compute_network.this.id
+  service = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [
+    google_compute_global_address.this.name
+  ]
+}

--- a/deployment/gcp/main.tf
+++ b/deployment/gcp/main.tf
@@ -5,8 +5,22 @@ provider "google" {
 
 module "gcp" {
   source       = "./gcp"
-  enable_ssh   = true
+  enable_ssh   = false
   ssh_key_path = "/Users/grant/.ssh/id_rsa.pub"
-  my_public_ip = "27.32.248.192/32"
 }
 
+# module "debugging_example" {
+# 	module "gcp" {
+#   source       = "./gcp"
+#   enable_ssh   = true
+#   ssh_key_path = "/Users/grant/.ssh/id_rsa.pub"
+#   my_public_ip = "17.42.249.192/32"
+# }
+
+# module "custom_ports" {
+# 	module "gcp" {
+#   source       = "./gcp"
+# 	controller_api_port = 9210
+# 	controller_cluster_port = 9211
+# 	worker_port = 9212
+# }

--- a/deployment/gcp/main.tf
+++ b/deployment/gcp/main.tf
@@ -1,0 +1,12 @@
+provider "google" {
+  project = "go-gcp-demos"
+  region  = "australia-southeast1"
+}
+
+module "gcp" {
+  source       = "./gcp"
+  enable_ssh   = true
+  ssh_key_path = "/Users/grant/.ssh/id_rsa.pub"
+  my_public_ip = "27.32.248.192/32"
+}
+

--- a/deployment/gcp/outputs.tf
+++ b/deployment/gcp/outputs.tf
@@ -1,19 +1,3 @@
-output boundary_url {
-  value = module.gcp.boundary_url
-}
-
-output recovery_key {
-	value = module.gcp.recovery_key
-}
-
-output crypto_ring {
-	value = module.gcp.crypto_ring
-}
-
-output gcp_project {
-	value = module.gcp.gcp_project
-}
-
 output helper_text {
 	value = <<-EOF
 "These outputs assist with running the included boundary configuration. To do so, please take the following steps:
@@ -22,4 +6,8 @@ output helper_text {
 3. terraform plan -var url=$URL -var key_ring=$KEY_RING  -var recovery_key=$RECOVERY_KEY -var gcp_project=$GCP_PROJECT
 4. terraform apply -var url=$URL -var key_ring=$KEY_RING  -var recovery_key=$RECOVERY_KEY -var gcp_project=$GCP_PROJECT"
 EOF
+}
+
+output target_ip {
+	value = module.gcp.target_ip
 }

--- a/deployment/gcp/outputs.tf
+++ b/deployment/gcp/outputs.tf
@@ -9,5 +9,5 @@ EOF
 }
 
 output target_ip {
-	value = module.gcp.target_ip
+	value = [ module.gcp.target_ip ]
 }

--- a/deployment/gcp/outputs.tf
+++ b/deployment/gcp/outputs.tf
@@ -1,5 +1,5 @@
 output boundary_url {
-  value = "Go to http://${module.gcp.boundary_api_public_ip}:${module.gcp.boundary_api_port} to access Boundary."
+  value = module.gcp.boundary_url
 }
 
 output recovery_key {
@@ -12,4 +12,14 @@ output crypto_ring {
 
 output gcp_project {
 	value = module.gcp.gcp_project
+}
+
+output helper_text {
+	value = <<-EOF
+"These outputs assist with running the included boundary configuration. To do so, please take the following steps:
+1. export URL=${module.gcp.boundary_url} && export RECOVERY_KEY=${module.gcp.recovery_key} && export KEY_RING=${module.gcp.crypto_ring} && export GCP_PROJECT=${module.gcp.gcp_project}
+2. cd ./boundary && terraform init
+3. terraform plan -var url=$URL -var key_ring=$KEY_RING  -var recovery_key=$RECOVERY_KEY -var gcp_project=$GCP_PROJECT
+4. terraform apply -var url=$URL -var key_ring=$KEY_RING  -var recovery_key=$RECOVERY_KEY -var gcp_project=$GCP_PROJECT"
+EOF
 }

--- a/deployment/gcp/outputs.tf
+++ b/deployment/gcp/outputs.tf
@@ -1,0 +1,15 @@
+output boundary_url {
+  value = "Go to http://${module.gcp.boundary_api_public_ip}:${module.gcp.boundary_api_port} to access Boundary."
+}
+
+output recovery_key {
+	value = module.gcp.recovery_key
+}
+
+output crypto_ring {
+	value = module.gcp.crypto_ring
+}
+
+output gcp_project {
+	value = module.gcp.gcp_project
+}


### PR DESCRIPTION
Hey folks, this PR is for a working deployment of Boundary on GCP.

I'm contemplating a minimal change to split the controller and worker configs into separate files for easier comprehension for those using this as a basis for their own deployments. (EDIT: I went ahead and did this)

No public facing DNS resources are used here, as I didn't want to make an assumption about what customers are using for that service.

Open to any feedback/changes that you might have.