### PR TITLE
Always use latest version of Boundary

### DIFF
--- a/deployment/azure/README.md
+++ b/deployment/azure/README.md
@@ -16,7 +16,7 @@ terraform init
 terraform apply -target module.azure
 ```
 
-This will spin up only the Azure infrastructure by targeting the Azure module. You can specify the version of Boundary you would like installed by using the variable `boundary_version`. By default it will use version `0.1.8`.
+This will spin up only the Azure infrastructure by targeting the Azure module. You can specify the version of Boundary you would like installed by using the variable `boundary_version`. By default it will use the latest version.
 
 Once the infrastructure is finished provisioning, the output will be used to configure boundary. The configuration will create an SSH keypair and a self-signed certificate for TLS. The self-signed certificate is uploaded to the Key Vault. You will need to add the certificate to your trusted certificate authorities to move forward with the Boundary configuration. A future enhancement to the Boundary Terraform provider will allow you to skip TLS certificate validation.
 
@@ -36,7 +36,7 @@ The first controller VM and the first worker VM are accessible via a NAT rule on
 Example:
 
 ```
-terraform apply -var boundary_version=0.1.8
+terraform apply -var boundary_version=VERSION # If specific version required
 ```
 
 The rest of the value for the Boundary config will come from the Azure module outputs.

--- a/deployment/azure/azure/boundary.tmpl
+++ b/deployment/azure/azure/boundary.tmpl
@@ -26,7 +26,7 @@ sudo cp $secretsname.crt /etc/pki/tls/boundary/cert.crt
 # TODO: pass boundary version through a variable
 curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
 sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
-sudo apt-get update && sudo apt-get install boundary=${boundary_version} -y
+sudo apt-get update && sudo apt-get install boundary${boundary_version != "latest" ? "=" +  boundary_version} -y
 
 # Get private ip address
 private_ip=$(hostname -i | awk '{print $1}')

--- a/deployment/azure/azure/variables.tf
+++ b/deployment/azure/azure/variables.tf
@@ -76,7 +76,7 @@ variable "cert_cn" {
 
 variable "boundary_version" {
   type    = string
-  default = "0.1.8"
+  default = "latest"
 }
 
 resource "random_id" "id" {

--- a/deployment/azure/main.tf
+++ b/deployment/azure/main.tf
@@ -1,6 +1,6 @@
 variable "boundary_version" {
   type    = string
-  default = "0.1.8"
+  default = "latest"
 }
 
 module "azure" {

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -60,3 +60,13 @@ PONG
 ```
 
 Explore the other containers such as Cassandra and Mysql (default passwords are set via env vars in the docker-compose.yml file).
+
+## Troubleshooting
+
+### DNS not Recongized on `boundary connect`
+
+If you are having issues connecting to Boundary when running `boundary connect`, it is likely due to the fact that you have no DNS entry for the worker. Add the following to your /etc/hosts file (or `c:\windows\system32\drivers\etc\hosts` on Windows):
+
+```
+127.0.0.1 boundary
+```

--- a/deployment/docker/compose/boundary.hcl
+++ b/deployment/docker/compose/boundary.hcl
@@ -1,55 +1,57 @@
 disable_mlock = true
 
 controller {
-  name = "docker-controller"
+  name        = "docker-controller"
   description = "A controller for a docker demo!"
+
   database {
-      url = "env://BOUNDARY_PG_URL"
+    url = "env://BOUNDARY_PG_URL"
   }
 }
 
 worker {
-  name = "docker-worker"
+  name        = "docker-worker"
   description = "A worker for a docker demo"
-  address = "boundary"
+  address     = "boundary"
 }
 
 listener "tcp" {
-  address = "boundary"
-  purpose = "api"
-  tls_disable = true 
+  address              = "boundary"
+  purpose              = "api"
+  tls_disable          = true
+  cors_enabled         = true
+  cors_allowed_origins = ["*"]
 }
 
 listener "tcp" {
-  address = "boundary"
-  purpose = "cluster"
-  tls_disable = true 
+  address     = "boundary"
+  purpose     = "cluster"
+  tls_disable = true
 }
 
 listener "tcp" {
-	address = "boundary"
-	purpose = "proxy"
-	tls_disable = true
+  address     = "boundary"
+  purpose     = "proxy"
+  tls_disable = true
 }
 
 kms "aead" {
-  purpose = "root"
+  purpose   = "root"
   aead_type = "aes-gcm"
-  key = "sP1fnF5Xz85RrXyELHFeZg9Ad2qt4Z4bgNHVGtD6ung="
-  key_id = "global_root"
+  key       = "sP1fnF5Xz85RrXyELHFeZg9Ad2qt4Z4bgNHVGtD6ung="
+  key_id    = "global_root"
 }
 
 kms "aead" {
-  purpose = "worker-auth"
+  purpose   = "worker-auth"
   aead_type = "aes-gcm"
-  key = "8fZBjCUfN0TzjEGLQldGY4+iE9AkOvCfjh7+p0GtRBQ="
-  key_id = "global_worker-auth"
+  key       = "8fZBjCUfN0TzjEGLQldGY4+iE9AkOvCfjh7+p0GtRBQ="
+  key_id    = "global_worker-auth"
 }
 
 kms "aead" {
-  purpose = "recovery"
+  purpose   = "recovery"
   aead_type = "aes-gcm"
-  key = "8fZBjCUfN0TzjEGLQldGY4+iE9AkOvCfjh7+p0GtRBQ="
-  key_id = "global_recovery"
+  key       = "8fZBjCUfN0TzjEGLQldGY4+iE9AkOvCfjh7+p0GtRBQ="
+  key_id    = "global_recovery"
 }
-

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   db-init:
-    image: hashicorp/boundary:0.1.8
+    image: hashicorp/boundary:latest
     command: ["database", "init", "-config", "/boundary/boundary.hcl"]
     volumes:
       - "${PWD}/:/boundary/"
@@ -28,7 +28,7 @@ services:
 
 
   boundary:
-    image: hashicorp/boundary:0.1.8
+    image: hashicorp/boundary:latest
     command: ["server", "-config", "/boundary/boundary.hcl"]
     volumes:
       - "${PWD}/:/boundary/"

--- a/deployment/docker/terraform/main.tf
+++ b/deployment/docker/terraform/main.tf
@@ -304,3 +304,7 @@ resource "boundary_target" "mssql" {
     boundary_host_set.local.id
   ]
 }
+
+output "auth_method_id" {
+  value = boundary_auth_method.password.id
+}

--- a/deployment/kube/kubernetes/boundary.tf
+++ b/deployment/kube/kubernetes/boundary.tf
@@ -34,7 +34,7 @@ resource "kubernetes_deployment" "boundary" {
 
         init_container {
           name    = "boundary-init"
-          image   = "hashicorp/boundary:0.1.8"
+          image   = "hashicorp/boundary:latest"
           command = ["/bin/sh", "-c"]
           args    = ["boundary database init -config /boundary/boundary.hcl"]
 
@@ -57,7 +57,7 @@ resource "kubernetes_deployment" "boundary" {
         }
 
         container {
-          image = "hashicorp/boundary:0.1.8"
+          image = "hashicorp/boundary:latest"
           name  = "boundary"
 
           volume_mount {


### PR DESCRIPTION
This ensures that the latest version of Boundary is always used when
it's explicitly specified in code (some examples, like AWS, currently
rely on a local binary to upload, so those were not altered).

It also adds some explicit CORS rules for the Docker example, where it's
necessary to ensure that the Boundary UI now works.

Finally, some notes in the Docker example have been added to note that
you may need an entry in your /etc/hosts file to ensure that you can
connect to the workers.