### PR TITLE
Typo on Kubernetes Deployment Example

### DIFF
--- a/deployment/kube/kubernetes/boundary_config.tf
+++ b/deployment/kube/kubernetes/boundary_config.tf
@@ -17,7 +17,7 @@ controller {
 }
 
 worker {
-	name = "kubernete-worker"
+	name = "kubernetes-worker"
 	description = "A worker for a kubernetes demo"
 	address = "localhost"
   controllers = ["localhost"]


### PR DESCRIPTION
A very small PR to fix a typo that I found on the `boundary_config.tf` file while I was going through the Kubernetes Deployment Example.