### PR TITLE
on the net.tf still had provider version; removed now valid

### DIFF
--- a/deployment/aws/aws/net.tf
+++ b/deployment/aws/aws/net.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  version = "~> 3.0"
   region  = "us-east-1"
 }
 

--- a/deployment/aws/aws/net.tf
+++ b/deployment/aws/aws/net.tf
@@ -1,6 +1,10 @@
-provider "aws" {
-  region  = "us-east-1"
-}
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+     }
+   }
+ }
 
 data "aws_availability_zones" "available" {
   state = "available"


### PR DESCRIPTION
Hi Joe! 

I do believe the `version =` block is not needed here. Let me know why you think! 