### PR TITLE
kube/kubernetes/kubernetes.tf: Set default config_path

### DIFF
--- a/deployment/kube/kubernetes/kubernetes.tf
+++ b/deployment/kube/kubernetes/kubernetes.tf
@@ -1,3 +1,4 @@
 provider "kubernetes" {
   config_context_cluster = "minikube"
+  config_path = "~/.kube/config"
 }


### PR DESCRIPTION
This is the default kube config path, majority of users I know don't set the KUBE_CONFIG_PATH env variable but have the path in the default location.

Closes https://github.com/hashicorp/boundary-reference-architecture/issues/50.
