### PR TITLE
NAT gateways should be place in the public subnets

### DIFF
--- a/deployment/aws/aws/net.tf
+++ b/deployment/aws/aws/net.tf
@@ -52,8 +52,8 @@ resource "aws_eip" "nat" {
 }
 
 resource "aws_nat_gateway" "private" {
-  count         = var.num_subnets_private
-  subnet_id     = aws_subnet.private.*.id[count.index]
+  count         = var.num_subnets_public
+  subnet_id     = aws_subnet.public.*.id[count.index]
   allocation_id = aws_eip.nat.*.id[count.index]
   tags          = local.tags
 }


### PR DESCRIPTION
@malnick the NAT gateways should be in the public subnets. Otherwise your private instances will have no internet outbound connection. Now the ec2 target instance can't download a package for instance. 