### PR TITLE
Add probes for boundary container

### DIFF
--- a/deployment/kube/kubernetes/boundary.tf
+++ b/deployment/kube/kubernetes/boundary.tf
@@ -88,6 +88,20 @@ resource "kubernetes_deployment" "boundary" {
           port {
             container_port = 9202
           }
+
+          liveness_probe {
+            http_get {
+              path = "/"
+              port = 9200
+            }
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/"
+              port = 9200
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## WHY

For reliable deployments. We should configure these probes.