### PR TITLE
feat: support m1 mac in docker reference

### DIFF
--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -35,9 +35,11 @@ To stop all containers and start from scratch:
 
 Login to the UI:
   - Open browser to localhost:9200
-  - Login Name: <any user from var.users>
+  - Login Name: <any user from terraform var.users>
   - Password: foofoofoo
   - Auth method ID: find this in the UI when selecting the auth method or from TF output
+
+If you did not use `./run login`, you can also login by hand:
 
 ```bash
 $ boundary authenticate password -login-name jeff -password foofoofoo -auth-method-id <get_from_console_or_tf>
@@ -54,8 +56,16 @@ Authentication information:
 Once the deployment is live, you can connect to the containers (assuming their clients are
 installed on your host system). For example, we'll use [redis-cli](https://redis.io/topics/rediscli) to ping the Redis container via Boundary:
 
+First find the target ID of the redis target:
+
 ```bash
-$ boundary connect -exec redis-cli -target-id ttcp_Mgvxjg8pjP -- -p {{boundary.port}} ping
+boundary targets list -recursive -filter '"/item/name" matches "redis"'
+```
+
+And then connect:
+
+```bash
+$ boundary connect -exec redis-cli -target-id <ttcp_id> -- -p {{boundary.port}} ping
 PONG
 ```
 

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   db-init:
-    image: hashicorp/boundary:0.7.1
+    image: hashicorp/boundary:0.7.5
     command: ["database", "init", "-config", "/boundary/boundary.hcl"]
     volumes:
       - "${PWD}/:/boundary:ro,z"
@@ -30,7 +30,7 @@ services:
 
 
   boundary:
-    image: hashicorp/boundary:0.7.1
+    image: hashicorp/boundary:0.7.5
     command: ["server", "-config", "/boundary/boundary.hcl"]
     volumes:
       - "${PWD}/:/boundary/"
@@ -49,8 +49,8 @@ services:
       interval: 3s
       timeout: 5s
       retries: 5
-# Boundary controller is the last service to start and may not be fully up 
-# by the time the docker compose command returns, so we force a wait by 
+# Boundary controller is the last service to start and may not be fully up
+# by the time the docker compose command returns, so we force a wait by
 # depending a placeholder on the controller healthcheck
   wait:
     image: busybox:latest
@@ -64,7 +64,7 @@ services:
     image: bitnami/cassandra:latest
 
   mysql:
-    image: mysql
+    image: mariadb
     environment:
       - 'MYSQL_ROOT_PASSWORD=my-secret-pw'
 


### PR DESCRIPTION
There is no longer an `image: mysql` that supports Apple M1 Macs.  I made roughly the same changes in https://github.com/hashicorp/learn-boundary-target-aware-workers/pull/2 recently and `mariadb` is a drop-in replacement.