### PR TITLE
Update postgres engine & instance class to latest usable version

### DIFF
--- a/deployment/aws/aws/db.tf
+++ b/deployment/aws/aws/db.tf
@@ -2,8 +2,8 @@ resource "aws_db_instance" "boundary" {
   allocated_storage   = 20
   storage_type        = "gp2"
   engine              = "postgres"
-  engine_version      = "11.8"
-  instance_class      = "db.t2.micro"
+  engine_version      = "14.2"
+  instance_class      = "db.t3.micro"
   name                = "boundary"
   username            = "boundary"
   password            = "boundarydemo"

--- a/deployment/aws/aws/ec2.tf
+++ b/deployment/aws/aws/ec2.tf
@@ -53,12 +53,12 @@ resource "aws_instance" "worker" {
 
   provisioner "file" {
     source      = "${var.boundary_bin}/boundary"
-    destination = "~/boundary"
+    destination = "/tmp/boundary"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv ~/boundary /usr/local/bin/boundary",
+      "sudo mv /tmp/boundary /usr/local/bin/boundary",
       "sudo chmod 0755 /usr/local/bin/boundary",
     ]
   }
@@ -75,22 +75,22 @@ resource "aws_instance" "worker" {
       kms_type               = var.kms_type
       kms_worker_auth_key_id = aws_kms_key.worker_auth.id
     })
-    destination = "~/boundary-worker.hcl"
+    destination = "/tmp/boundary-worker.hcl"
   }
 
   provisioner "remote-exec" {
-    inline = ["sudo mv ~/boundary-worker.hcl /etc/boundary-worker.hcl"]
+    inline = ["sudo mv /tmp/boundary-worker.hcl /etc/boundary-worker.hcl"]
   }
 
   provisioner "file" {
     source      = "${path.module}/install/install.sh"
-    destination = "~/install.sh"
+    destination = "/home/ubuntu/install.sh"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo chmod 0755 ~/install.sh",
-      "sudo ~/./install.sh worker"
+      "sudo chmod 0755 /home/ubuntu/install.sh",
+      "sudo /home/ubuntu/install.sh worker"
     ]
   }
 
@@ -129,12 +129,12 @@ resource "aws_instance" "controller" {
 
   provisioner "file" {
     source      = "${var.boundary_bin}/boundary"
-    destination = "~/boundary"
+    destination = "/tmp/boundary"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo mv ~/boundary /usr/local/bin/boundary",
+      "sudo mv /tmp/boundary /usr/local/bin/boundary",
       "sudo chmod 0755 /usr/local/bin/boundary",
     ]
   }
@@ -152,22 +152,22 @@ resource "aws_instance" "controller" {
       kms_recovery_key_id    = aws_kms_key.recovery.id
       kms_root_key_id        = aws_kms_key.root.id
     })
-    destination = "~/boundary-controller.hcl"
+    destination = "/tmp/boundary-controller.hcl"
   }
 
   provisioner "remote-exec" {
-    inline = ["sudo mv ~/boundary-controller.hcl /etc/boundary-controller.hcl"]
+    inline = ["sudo mv /tmp/boundary-controller.hcl /etc/boundary-controller.hcl"]
   }
 
   provisioner "file" {
     source      = "${path.module}/install/install.sh"
-    destination = "~/install.sh"
+    destination = "/home/ubuntu/install.sh"
   }
 
   provisioner "remote-exec" {
     inline = [
-      "sudo chmod 0755 ~/install.sh",
-      "sudo ~/./install.sh controller"
+      "sudo chmod 0755 /home/ubuntu/install.sh",
+      "sudo sh /home/ubuntu/install.sh controller"
     ]
   }
 


### PR DESCRIPTION
**Changes:** 
This PR upgrades Postgres to the most recent and usable version, as 11.8 is no longer supported by AWS.  Additionally, _db.t2.micro_ is no longer a valid instance class, so we've bumped up to the next available size that runs at the same price(.017/h - https://aws.amazon.com/rds/mysql/pricing/). 

