### PR TITLE
Update postgres engine & instance class to latest usable version

### DIFF
--- a/deployment/aws/aws/db.tf
+++ b/deployment/aws/aws/db.tf
@@ -2,8 +2,8 @@ resource "aws_db_instance" "boundary" {
   allocated_storage   = 20
   storage_type        = "gp2"
   engine              = "postgres"
-  engine_version      = "11.8"
-  instance_class      = "db.t2.micro"
+  engine_version      = "14.2"
+  instance_class      = "db.t3.micro"
   name                = "boundary"
   username            = "boundary"
   password            = "boundarydemo"


### PR DESCRIPTION
*Changes:*
This PR upgrades Postgres to the most recent and usable version, as 11.8 is no longer supported by AWS. Additionally, db.t2.micro is no longer a valid instance class, so we've bumped up to the next available size that runs at the same price(.017/h - https://aws.amazon.com/rds/mysql/pricing/).