### PR TITLE
[WIP] Boundary TF Provider updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Local .terraform directories
 **/.terraform/*
+.terraform
 
 # .tfstate files
 **/*.tfstate

--- a/deployment/aws/aws/cert.tf
+++ b/deployment/aws/aws/cert.tf
@@ -24,6 +24,6 @@ resource "aws_acm_certificate" "cert" {
   certificate_body = tls_self_signed_cert.boundary.cert_pem
 
   tags = {
-    Name = "${var.tag}-${random_pet.test.id}"
+    Name = "${var.tag}-${random_string.test.id}"
   }
 }

--- a/deployment/aws/aws/cert.tf
+++ b/deployment/aws/aws/cert.tf
@@ -3,7 +3,6 @@ resource "tls_private_key" "boundary" {
 }
 
 resource "tls_self_signed_cert" "boundary" {
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.boundary.private_key_pem
 
   subject {

--- a/deployment/aws/aws/db.tf
+++ b/deployment/aws/aws/db.tf
@@ -22,7 +22,7 @@ resource "aws_security_group" "db" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = "${var.tag}-db-${random_pet.test.id}"
+    Name = "${var.tag}-db-${random_string.test.id}"
   }
 }
 
@@ -45,10 +45,10 @@ resource "aws_security_group_rule" "allow_any_ingress" {
 }
 
 resource "aws_db_subnet_group" "boundary" {
-  name       = "boundary"
+  name       = lower("boundary-${random_string.test.id}")
   subnet_ids = aws_subnet.public.*.id
 
   tags = {
-    Name = "${var.tag}-db-${random_pet.test.id}"
+    Name = "${var.tag}-db-${random_string.test.id}"
   }
 }

--- a/deployment/aws/aws/db.tf
+++ b/deployment/aws/aws/db.tf
@@ -4,7 +4,7 @@ resource "aws_db_instance" "boundary" {
   engine              = "postgres"
   engine_version      = "14.2"
   instance_class      = "db.t3.micro"
-  name                = "boundary"
+  db_name             = "boundary"
   username            = "boundary"
   password            = "boundarydemo"
   skip_final_snapshot = true

--- a/deployment/aws/aws/ec2.tf
+++ b/deployment/aws/aws/ec2.tf
@@ -1,5 +1,5 @@
 locals {
-  priv_ssh_key_real = coalesce(var.priv_ssh_key_path,trimsuffix(var.pub_ssh_key_path,".pub"))
+  priv_ssh_key_real = coalesce(var.priv_ssh_key_path, trimsuffix(var.pub_ssh_key_path, ".pub"))
 }
 
 resource "aws_key_pair" "boundary" {

--- a/deployment/aws/aws/ec2.tf
+++ b/deployment/aws/aws/ec2.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 resource "aws_key_pair" "boundary" {
-  key_name   = "${var.tag}-${random_pet.test.id}"
+  key_name   = "${var.tag}-${random_string.test.id}"
   public_key = file(var.pub_ssh_key_path)
 
   tags = local.tags
@@ -95,7 +95,7 @@ resource "aws_instance" "worker" {
   }
 
   tags = {
-    Name = "${var.tag}-worker-${random_pet.test.id}"
+    Name = "${var.tag}-worker-${random_string.test.id}-${count.index}"
   }
 
   depends_on = [aws_instance.controller]
@@ -172,7 +172,7 @@ resource "aws_instance" "controller" {
   }
 
   tags = {
-    Name = "${var.tag}-controller-${random_pet.test.id}"
+    Name = "${var.tag}-controller-${random_string.test.id}-${count.index}"
   }
 }
 
@@ -180,7 +180,7 @@ resource "aws_security_group" "controller" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = "${var.tag}-controller-${random_pet.test.id}"
+    Name = "${var.tag}-controller-${random_string.test.id}"
   }
 }
 
@@ -224,7 +224,7 @@ resource "aws_security_group" "worker" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = "${var.tag}-worker-${random_pet.test.id}"
+    Name = "${var.tag}-worker-${random_string.test.id}"
   }
 }
 
@@ -274,6 +274,6 @@ resource "aws_instance" "target" {
   vpc_security_group_ids = [aws_security_group.worker.id]
 
   tags = {
-    Name = "${var.tag}-target-${random_pet.test.id}"
+    Name = "${var.tag}-target-${random_string.test.id}"
   }
 }

--- a/deployment/aws/aws/iam.tf
+++ b/deployment/aws/aws/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "boundary" {
-  name = "${var.tag}-${random_pet.test.id}"
+  name = "${var.tag}-${random_string.test.id}"
 
   assume_role_policy = <<EOF
 {
@@ -18,17 +18,17 @@ resource "aws_iam_role" "boundary" {
 EOF
 
   tags = {
-    Name = "${var.tag}-${random_pet.test.id}"
+    Name = "${var.tag}-${random_string.test.id}"
   }
 }
 
 resource "aws_iam_instance_profile" "boundary" {
-  name = "${var.tag}-${random_pet.test.id}"
+  name = "${var.tag}-${random_string.test.id}"
   role = aws_iam_role.boundary.name
 }
 
 resource "aws_iam_role_policy" "boundary" {
-  name = "${var.tag}-${random_pet.test.id}"
+  name = "${var.tag}-${random_string.test.id}"
   role = aws_iam_role.boundary.id
 
   policy = <<EOF

--- a/deployment/aws/aws/kms.tf
+++ b/deployment/aws/aws/kms.tf
@@ -3,7 +3,7 @@ resource "aws_kms_key" "root" {
   deletion_window_in_days = 10
 
   tags = {
-    Name = "${var.tag}-${random_pet.test.id}"
+    Name = "${var.tag}-${random_string.test.id}"
   }
 }
 
@@ -12,7 +12,7 @@ resource "aws_kms_key" "worker_auth" {
   deletion_window_in_days = 10
 
   tags = {
-    Name = "${var.tag}-${random_pet.test.id}"
+    Name = "${var.tag}-${random_string.test.id}"
   }
 }
 
@@ -21,6 +21,6 @@ resource "aws_kms_key" "recovery" {
   deletion_window_in_days = 10
 
   tags = {
-    Name = "${var.tag}-${random_pet.test.id}"
+    Name = "${var.tag}-${random_string.test.id}"
   }
 }

--- a/deployment/aws/aws/lb.tf
+++ b/deployment/aws/aws/lb.tf
@@ -1,16 +1,16 @@
 resource "aws_lb" "controller" {
-  name               = "${var.tag}-controller-${random_pet.test.id}"
+  name               = "${var.tag}-controller-${random_string.test.id}"
   load_balancer_type = "network"
   internal           = false
   subnets            = aws_subnet.public.*.id
 
   tags = {
-    Name = "${var.tag}-controller-${random_pet.test.id}"
+    Name = "${var.tag}-controller-${random_string.test.id}"
   }
 }
 
 resource "aws_lb_target_group" "controller" {
-  name     = "${var.tag}-controller-${random_pet.test.id}"
+  name     = "${var.tag}-controller-${random_string.test.id}"
   port     = 9200
   protocol = "TCP"
   vpc_id   = aws_vpc.main.id
@@ -20,7 +20,7 @@ resource "aws_lb_target_group" "controller" {
     type    = "source_ip"
   }
   tags = {
-    Name = "${var.tag}-controller-${random_pet.test.id}"
+    Name = "${var.tag}-controller-${random_string.test.id}"
   }
 }
 
@@ -46,7 +46,7 @@ resource "aws_security_group" "controller_lb" {
   vpc_id = aws_vpc.main.id
 
   tags = {
-    Name = "${var.tag}-controller-lb-${random_pet.test.id}"
+    Name = "${var.tag}-controller-lb-${random_string.test.id}"
   }
 }
 

--- a/deployment/aws/aws/net.tf
+++ b/deployment/aws/aws/net.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  version = "~> 3.0"
   region  = "us-east-1"
 }
 

--- a/deployment/aws/aws/net.tf
+++ b/deployment/aws/aws/net.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region  = "us-east-1"
+  region = "us-east-1"
 }
 
 data "aws_availability_zones" "available" {

--- a/deployment/aws/aws/net.tf
+++ b/deployment/aws/aws/net.tf
@@ -29,7 +29,7 @@ resource "aws_subnet" "public" {
   cidr_block        = local.pub_cidrs[count.index]
 
   tags = {
-    Name = "${var.tag}-${random_pet.test.id}-public-${count.index}"
+    Name = "${var.tag}-${random_string.test.id}-public-${count.index}"
   }
 }
 
@@ -40,7 +40,7 @@ resource "aws_subnet" "private" {
   cidr_block        = local.priv_cidrs[count.index]
 
   tags = {
-    Name = "${var.tag}-${random_pet.test.id}-private-${count.index}"
+    Name = "${var.tag}-${random_string.test.id}-private-${count.index}"
   }
 }
 
@@ -62,7 +62,7 @@ resource "aws_route_table" "public" {
   count  = var.num_subnets_public
   vpc_id = aws_vpc.main.id
   tags = {
-    Name = "${var.tag}-${random_pet.test.id}-public-${count.index}"
+    Name = "${var.tag}-${random_string.test.id}-public-${count.index}"
   }
 }
 
@@ -88,7 +88,7 @@ resource "aws_route_table" "private" {
   count  = var.num_subnets_private
   vpc_id = aws_vpc.main.id
   tags = {
-    Name = "${var.tag}-${random_pet.test.id}-private-${count.index}"
+    Name = "${var.tag}-${random_string.test.id}-private-${count.index}"
   }
 }
 

--- a/deployment/aws/aws/vars.tf
+++ b/deployment/aws/aws/vars.tf
@@ -1,10 +1,11 @@
-resource "random_pet" "test" {
-  length = 1
+resource "random_string" "test" {
+  length  = 5
+  special = false
 }
 
 locals {
   tags = {
-    Name = "${var.tag}-${random_pet.test.id}"
+    Name = "${var.tag}-${random_string.test.id}"
   }
 
   pub_cidrs  = cidrsubnets("10.0.0.0/24", 4, 4, 4, 4)

--- a/deployment/aws/boundary/hosts.tf
+++ b/deployment/aws/boundary/hosts.tf
@@ -1,23 +1,20 @@
-resource "boundary_host_catalog" "backend_servers" {
+resource "boundary_host_catalog_static" "backend_servers" {
   name        = "backend_servers"
   description = "Web servers for backend team"
-  type        = "static"
   scope_id    = boundary_scope.core_infra.id
 }
 
-resource "boundary_host" "backend_servers" {
+resource "boundary_host_static" "backend_servers" {
   for_each        = var.target_ips
-  type            = "static"
   name            = "backend_server_${each.value}"
   description     = "Backend server #${each.value}"
   address         = each.key
-  host_catalog_id = boundary_host_catalog.backend_servers.id
+  host_catalog_id = boundary_host_catalog_static.backend_servers.id
 }
 
-resource "boundary_host_set" "backend_servers" {
-  type            = "static"
+resource "boundary_host_set_static" "backend_servers" {
   name            = "backend_servers"
   description     = "Host set for backend servers"
-  host_catalog_id = boundary_host_catalog.backend_servers.id
-  host_ids        = [for host in boundary_host.backend_servers : host.id]
+  host_catalog_id = boundary_host_catalog_static.backend_servers.id
+  host_ids        = [for host in boundary_host_static.backend_servers : host.id]
 }

--- a/deployment/aws/boundary/main.tf
+++ b/deployment/aws/boundary/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     boundary = {
       source  = "hashicorp/boundary"
-      version = "1.0.7"
+      version = "1.0.6"
     }
   }
 }

--- a/deployment/aws/boundary/main.tf
+++ b/deployment/aws/boundary/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     boundary = {
       source  = "hashicorp/boundary"
-      version = "1.0.5"
+      version = "1.0.7"
     }
   }
 }

--- a/deployment/aws/boundary/principles.tf
+++ b/deployment/aws/boundary/principles.tf
@@ -2,7 +2,7 @@ resource "boundary_user" "backend" {
   for_each    = var.backend_team
   name        = each.key
   description = "Backend user: ${each.key}"
-  account_ids = [boundary_account.backend_user_acct[each.value].id]
+  account_ids = [boundary_account_password.backend_user_acct[each.value].id]
   scope_id    = boundary_scope.org.id
 }
 
@@ -10,7 +10,7 @@ resource "boundary_user" "frontend" {
   for_each    = var.frontend_team
   name        = each.key
   description = "Frontend user: ${each.key}"
-  account_ids = [boundary_account.frontend_user_acct[each.value].id]
+  account_ids = [boundary_account_password.frontend_user_acct[each.value].id]
   scope_id    = boundary_scope.org.id
 }
 
@@ -18,11 +18,11 @@ resource "boundary_user" "leadership" {
   for_each    = var.leadership_team
   name        = each.key
   description = "WARNING: Managers should be read-only"
-  account_ids = [boundary_account.leadership_user_acct[each.value].id]
+  account_ids = [boundary_account_password.leadership_user_acct[each.value].id]
   scope_id    = boundary_scope.org.id
 }
 
-resource "boundary_account" "backend_user_acct" {
+resource "boundary_account_password" "backend_user_acct" {
   for_each       = var.backend_team
   name           = each.key
   description    = "User account for ${each.key}"
@@ -32,7 +32,7 @@ resource "boundary_account" "backend_user_acct" {
   auth_method_id = boundary_auth_method.password.id
 }
 
-resource "boundary_account" "frontend_user_acct" {
+resource "boundary_account_password" "frontend_user_acct" {
   for_each       = var.frontend_team
   name           = each.key
   description    = "User account for ${each.key}"
@@ -42,7 +42,7 @@ resource "boundary_account" "frontend_user_acct" {
   auth_method_id = boundary_auth_method.password.id
 }
 
-resource "boundary_account" "leadership_user_acct" {
+resource "boundary_account_password" "leadership_user_acct" {
   for_each       = var.leadership_team
   name           = each.key
   description    = "User account for ${each.key}"

--- a/deployment/aws/boundary/targets.tf
+++ b/deployment/aws/boundary/targets.tf
@@ -5,8 +5,8 @@ resource "boundary_target" "backend_servers_ssh" {
   scope_id                 = boundary_scope.core_infra.id
   session_connection_limit = -1
   default_port             = 22
-  host_set_ids = [
-    boundary_host_set.backend_servers.id
+  host_source_ids = [
+    boundary_host_set_static.backend_servers.id
   ]
 }
 
@@ -17,7 +17,7 @@ resource "boundary_target" "backend_servers_website" {
   scope_id                 = boundary_scope.core_infra.id
   session_connection_limit = -1
   default_port             = 8000
-  host_set_ids = [
-    boundary_host_set.backend_servers.id
+  host_source_ids = [
+    boundary_host_set_static.backend_servers.id
   ]
 }

--- a/deployment/aws/boundary/vars.tf
+++ b/deployment/aws/boundary/vars.tf
@@ -1,6 +1,5 @@
 variable "url" {
   default = "http://127.0.0.1:9200"
-  #  default = "http://boundary-demo-controller-ec52c62e6a9979ab.elb.us-east-1.amazonaws.com:9200"
 }
 
 variable "backend_team" {

--- a/deployment/aws/main.tf
+++ b/deployment/aws/main.tf
@@ -1,7 +1,7 @@
 module "aws" {
-  source           = "./aws"
-  boundary_bin     = var.boundary_bin
-  pub_ssh_key_path = var.pub_ssh_key_path
+  source            = "./aws"
+  boundary_bin      = var.boundary_bin
+  pub_ssh_key_path  = var.pub_ssh_key_path
   priv_ssh_key_path = var.priv_ssh_key_path
 }
 


### PR DESCRIPTION
This is a PR for the AWS reference architecture which introduces some changes to the following:
- Terraform fmt was run cleaning up the TF code
- Nit: updated gitignore for .terraform directory
- Changed `random_pet` to `random_string` as I ran up against a name length limitation with `aws_lb` resource
- Minor AWS resource updates with the newer provider version (`aws_db_instance` naming)
- Minor Boundary resource changes to support `boundary_..._static` host bits, changing from `boundary_account` to `boundary_account_password` explicitly
- Bumping provider version to `v1.0.7`