### PR TITLE
Support for v0.9.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,25 @@
 **/id_ecdsa*
 **/id_ed25519*
 
+# Mutant Distros
+**/.DS_Store
+**/.AppleDouble
+**/.LSOverride
+**/Icon
+**/._*
+**/.DocumentRevisions-V100
+**/.fseventsd
+**/.Spotlight-V100
+**/.TemporaryItems
+**/.Trashes
+**/.VolumeIcon.icns
+**/.com.apple.timemachine.donotpresent
+**/.AppleDB
+**/.AppleDesktop
+**/Network Trash Folder
+**/Temporary Items
+**/.apdisk
+
 # Exclude all .tfvars files, which are likely to contain sensitive data, 
 # such as password, private keys, and other secrets. These should not be 
 # part of version control as they are data points which are potentially 

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   db-init:
-    image: hashicorp/boundary:0.7.5
+    image: hashicorp/boundary:0.9.0
     command: ["database", "init", "-config", "/boundary/boundary.hcl"]
     volumes:
       - "${PWD}/:/boundary:ro,z"
@@ -30,7 +30,7 @@ services:
 
 
   boundary:
-    image: hashicorp/boundary:0.7.5
+    image: hashicorp/boundary:0.9.0
     command: ["server", "-config", "/boundary/boundary.hcl"]
     volumes:
       - "${PWD}/:/boundary/"

--- a/deployment/docker/run
+++ b/deployment/docker/run
@@ -4,11 +4,12 @@ function cleanup() {
   pushd compose
   docker-compose rm -fs 
   popd
-  pushd terraform/
-  rm terraform.tfstate*
-  popd
+  # Purge the TF State
+  rm -rf ./terraform/.terraform
+  rm -rf ./terraform/.terraform.lock.hcl
   exit 0
 }
+
 trap cleanup SIGKILL SIGINT
 
 function init_compose() {

--- a/deployment/docker_cts/compose/cts/config.hcl
+++ b/deployment/docker_cts/compose/cts/config.hcl
@@ -46,7 +46,7 @@ driver "terraform" {
     }
     boundary = {
       source = "hashicorp/boundary"
-      version = "1.0.2"
+      version = "1.0.9"
     }
   }
 }

--- a/deployment/docker_cts/compose/cts/sync-tasks/boundary/boundary/main.tf
+++ b/deployment/docker_cts/compose/cts/sync-tasks/boundary/boundary/main.tf
@@ -1,40 +1,40 @@
 
 data "http" "scopes" {
-    url = "http://localhost:9200/v1/scopes"
+  url = "http://localhost:9200/v1/scopes"
 }
 
 data "http" "project" {
-    url = "http://localhost:9200/v1/scopes?scope_id=${local.primary_scope_id}"
+  url = "http://localhost:9200/v1/scopes?scope_id=${local.primary_scope_id}"
 }
 
 data "http" "host_catalogs" {
-    url = "http://localhost:9200/v1/host-catalogs?scope_id=${local.database_project_id}"
+  url = "http://localhost:9200/v1/host-catalogs?scope_id=${local.database_project_id}"
 }
 
 locals {
-    primary_scope_id = [for i in jsondecode(data.http.scopes.body).items : i.id if i.name == "primary"][0]
-    database_project_id = [for i in jsondecode(data.http.project.body).items : i.id if i.name == "databases"][0]
-    database_host_catalog_id = [for i in jsondecode(data.http.host_catalogs.body).items : i.id if i.name == "databases"][0]
-    # Create a map of service names to instance IDs to then build
-    # a map of service names to instances
-    consul_service_ids = transpose({
-      for id, s in var.services : id => [s.name]
-    })
+  primary_scope_id         = [for i in jsondecode(data.http.scopes.body).items : i.id if i.name == "primary"][0]
+  database_project_id      = [for i in jsondecode(data.http.project.body).items : i.id if i.name == "databases"][0]
+  database_host_catalog_id = [for i in jsondecode(data.http.host_catalogs.body).items : i.id if i.name == "databases"][0]
+  # Create a map of service names to instance IDs to then build
+  # a map of service names to instances
+  consul_service_ids = transpose({
+    for id, s in var.services : id => [s.name]
+  })
 
-    # Group service instances by service name
-    # consul_services = {
-    #   "app" = [
-    #     {
-    #       "id" = "app-id-01"
-    #       "name" = "app"
-    #       "node_address" = "192.168.10.10"
-    #     }
-    #   ]
-    # }
-    consul_services = {
-      for name, ids in local.consul_service_ids :
-      name => [for id in ids : var.services[id]]
-    }
+  # Group service instances by service name
+  # consul_services = {
+  #   "app" = [
+  #     {
+  #       "id" = "app-id-01"
+  #       "name" = "app"
+  #       "node_address" = "192.168.10.10"
+  #     }
+  #   ]
+  # }
+  consul_services = {
+    for name, ids in local.consul_service_ids :
+    name => [for id in ids : var.services[id]]
+  }
 }
 
 output "test" {
@@ -42,10 +42,10 @@ output "test" {
 }
 
 resource "boundary_host" "mysql" {
-  for_each = {for s in local.consul_services["mysql"] : s.id => s}
-  type        = "static"
-  name        = "mysql"
-  description = "Private mysql container"
+  for_each        = { for s in local.consul_services["mysql"] : s.id => s }
+  type            = "static"
+  name            = "mysql"
+  description     = "Private mysql container"
   address         = each.value.address
   host_catalog_id = local.database_host_catalog_id
 }
@@ -55,7 +55,7 @@ resource "boundary_host_set" "mysql" {
   name            = "mysql"
   description     = "Host set for mysql containers"
   host_catalog_id = local.database_host_catalog_id
-  host_ids        = [for k,v in boundary_host.mysql : v.id]
+  host_ids        = [for k, v in boundary_host.mysql : v.id]
 }
 
 resource "boundary_target" "mysql" {
@@ -72,10 +72,10 @@ resource "boundary_target" "mysql" {
 }
 
 resource "boundary_host" "redis" {
-  for_each = {for s in local.consul_services["redis"] : s.id => s}
-  type        = "static"
-  name        = each.key
-  description = "Private redis container"
+  for_each        = { for s in local.consul_services["redis"] : s.id => s }
+  type            = "static"
+  name            = each.key
+  description     = "Private redis container"
   address         = each.value.address
   host_catalog_id = local.database_host_catalog_id
 }
@@ -85,7 +85,7 @@ resource "boundary_host_set" "redis" {
   name            = "redis"
   description     = "Host set for redis containers"
   host_catalog_id = local.database_host_catalog_id
-  host_ids        = [for k,v in boundary_host.redis : v.id]
+  host_ids        = [for k, v in boundary_host.redis : v.id]
 }
 
 resource "boundary_target" "redis" {

--- a/deployment/docker_cts/compose/cts/sync-tasks/boundary/main.tf
+++ b/deployment/docker_cts/compose/cts/sync-tasks/boundary/main.tf
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     boundary = {
       source  = "hashicorp/boundary"
-      version = "1.0.2"
+      version = "1.0.9"
     }
   }
   backend "consul" {

--- a/deployment/docker_cts/compose/docker-compose.yml
+++ b/deployment/docker_cts/compose/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       retries: 5
 
   db-init:
-    image: hashicorp/boundary:0.2.3
+    image: hashicorp/boundary:0.9.0
     command: ["database", "init", "-config", "/boundary/boundary.hcl"]
     volumes:
       - "./:/boundary/"
@@ -28,7 +28,7 @@ services:
 
 
   boundary:
-    image: hashicorp/boundary:0.2.3
+    image: hashicorp/boundary:0.9.0
     hostname: boundary
     command: ["server", "-config", "/boundary/boundary.hcl"]
     restart: always

--- a/deployment/docker_cts/cts/sync-tasks/boundary/main.tf
+++ b/deployment/docker_cts/cts/sync-tasks/boundary/main.tf
@@ -12,7 +12,7 @@ terraform {
   required_providers {
     boundary = {
       source  = "hashicorp/boundary"
-      version = "1.0.2"
+      version = "1.0.9"
     }
   }
   backend "consul" {

--- a/deployment/docker_cts/terraform/main.tf
+++ b/deployment/docker_cts/terraform/main.tf
@@ -2,13 +2,13 @@ terraform {
   required_providers {
     boundary = {
       source  = "hashicorp/boundary"
-      version = "1.0.2"
+      version = "1.0.9"
     }
   }
   backend "consul" {
     address = "localhost:8500"
-    scheme = "http"
-    path = "terraform/boundary"
+    scheme  = "http"
+    path    = "terraform/boundary"
   }
 }
 
@@ -51,6 +51,8 @@ variable "users" {
     "kris",
     "chris",
     "swarna",
+    "mark",
+    "julia",
   ]
 }
 
@@ -78,35 +80,33 @@ resource "boundary_user" "user" {
   for_each    = var.users
   name        = each.key
   description = "User resource for ${each.key}"
-  account_ids = [boundary_account.user[each.value].id]
+  account_ids = [boundary_account_password.user[each.value].id]
   scope_id    = boundary_scope.org.id
 }
 
-resource "boundary_auth_method" "password" {
+resource "boundary_auth_method_password" "password" {
   name        = "org_password_auth"
   description = "Password auth method for org"
   type        = "password"
   scope_id    = boundary_scope.org.id
 }
 
-resource "boundary_account" "user" {
+resource "boundary_account_password" "user" {
   for_each       = var.users
   name           = each.key
   description    = "User account for ${each.key}"
   type           = "password"
   login_name     = lower(each.key)
   password       = "foofoofoo"
-  auth_method_id = boundary_auth_method.password.id
+  auth_method_id = boundary_auth_method_password.password.id
 }
 
 resource "boundary_role" "global_anon_listing" {
   scope_id = boundary_scope.global.id
   grant_strings = [
     "id=*;type=auth-method;actions=list,authenticate",
-    "id=*;type=scope;actions=*",
-    "id={{account.id}};actions=read,change-password",
-    "id=*;type=host-catalog;actions=*",
-    "type=host-catalog;actions=list"
+    "type=scope;actions=list",
+    "id={{account.id}};actions=read,change-password"
   ]
   principal_ids = ["u_anon"]
 }
@@ -115,10 +115,8 @@ resource "boundary_role" "org_anon_listing" {
   scope_id = boundary_scope.org.id
   grant_strings = [
     "id=*;type=auth-method;actions=list,authenticate",
-    "id=*;type=scope;actions=*",
-    "id={{account.id}};actions=read,change-password",
-    "id=*;type=host-catalog;actions=*",
-    "type=host-catalog;actions=list"
+    "type=scope;actions=list",
+    "id={{account.id}};actions=read,change-password"
   ]
   principal_ids = ["u_anon"]
 }
@@ -142,44 +140,31 @@ resource "boundary_role" "proj_admin" {
   )
 }
 
-resource "boundary_role" "proj_anon_listing" {
-  scope_id = boundary_scope.org.id
-  grant_scope_id = boundary_scope.project.id
-  grant_strings = [
-    "id=*;type=auth-method;actions=list,authenticate",
-    "id=*;type=scope;actions=*",
-    "id={{account.id}};actions=read,change-password",
-    "id=*;type=host-catalog;actions=*",
-    "type=host-catalog;actions=list"
-  ]
-  principal_ids = ["u_anon"]
-}
-
-resource "boundary_host_catalog" "databases" {
+resource "boundary_host_catalog_static" "databases" {
   name        = "databases"
   description = "Database targets"
-  type        = "static"
+  # type        = "static"
   scope_id    = boundary_scope.project.id
 }
 
-resource "boundary_host" "localhost" {
+resource "boundary_host_static" "localhost" {
   type            = "static"
   name            = "localhost"
   description     = "Localhost host"
   address         = "localhost"
-  host_catalog_id = boundary_host_catalog.databases.id
+  host_catalog_id = boundary_host_catalog_static.databases.id
 }
 
 # Target hosts available on localhost: ssh and postgres
 # Postgres is exposed to localhost for debugging of the 
 # Boundary DB from the CLI. Assumes SSHD is running on
 # localhost.
-resource "boundary_host_set" "local" {
+resource "boundary_host_set_static" "local" {
   type            = "static"
   name            = "local"
   description     = "Host set for local servers"
-  host_catalog_id = boundary_host_catalog.databases.id
-  host_ids        = [boundary_host.localhost.id]
+  host_catalog_id = boundary_host_catalog_static.databases.id
+  host_ids        = [boundary_host_static.localhost.id]
 }
 
 resource "boundary_target" "ssh" {
@@ -190,8 +175,8 @@ resource "boundary_target" "ssh" {
   session_connection_limit = -1
   session_max_seconds      = 2
   default_port             = 22
-  host_set_ids = [
-    boundary_host_set.local.id
+  host_source_ids = [
+    boundary_host_set_static.local.id
   ]
 }
 
@@ -203,11 +188,170 @@ resource "boundary_target" "postgres" {
   session_connection_limit = -1
   session_max_seconds      = 2
   default_port             = 5432
-  host_set_ids = [
-    boundary_host_set.local.id
+  host_source_ids = [
+    boundary_host_set_static.local.id
   ]
 }
 
+resource "boundary_host_static" "cassandra" {
+  type        = "static"
+  name        = "cassandra"
+  description = "Private cassandra container"
+  # DNS set via docker-compose
+  address         = "cassandra"
+  host_catalog_id = boundary_host_catalog_static.databases.id
+}
+
+resource "boundary_host_set_static" "cassandra" {
+  type            = "static"
+  name            = "cassandra"
+  description     = "Host set for cassandra containers"
+  host_catalog_id = boundary_host_catalog_static.databases.id
+  host_ids        = [boundary_host_static.cassandra.id]
+}
+
+resource "boundary_target" "cassandra" {
+  type                     = "tcp"
+  name                     = "cassandra"
+  description              = "Cassandra server"
+  scope_id                 = boundary_scope.project.id
+  session_connection_limit = -1
+  session_max_seconds      = 2
+  default_port             = 7000
+  host_source_ids = [
+    boundary_host_set_static.cassandra.id
+  ]
+}
+
+resource "boundary_host_static" "mysql" {
+  type        = "static"
+  name        = "mysql"
+  description = "Private mysql container"
+  # DNS set via docker-compose
+  address         = "mysql"
+  host_catalog_id = boundary_host_catalog_static.databases.id
+}
+
+resource "boundary_host_set_static" "mysql" {
+  type            = "static"
+  name            = "mysql"
+  description     = "Host set for mysql containers"
+  host_catalog_id = boundary_host_catalog_static.databases.id
+  host_ids        = [boundary_host_static.mysql.id]
+}
+
+resource "boundary_target" "mysql" {
+  type                     = "tcp"
+  name                     = "mysql"
+  description              = "MySQL server"
+  scope_id                 = boundary_scope.project.id
+  session_connection_limit = -1
+  session_max_seconds      = 2
+  default_port             = 3306
+  host_source_ids = [
+    boundary_host_set_static.mysql.id
+  ]
+}
+
+resource "boundary_host_static" "redis" {
+  type        = "static"
+  name        = "redis"
+  description = "Private redis container"
+  # DNS set via docker-compose
+  address         = "redis"
+  host_catalog_id = boundary_host_catalog_static.databases.id
+}
+
+resource "boundary_host_set_static" "redis" {
+  type            = "static"
+  name            = "redis"
+  description     = "Host set for redis containers"
+  host_catalog_id = boundary_host_catalog_static.databases.id
+  host_ids        = [boundary_host_static.redis.id]
+}
+
+resource "boundary_target" "redis" {
+  type                     = "tcp"
+  name                     = "redis"
+  description              = "Redis server"
+  scope_id                 = boundary_scope.project.id
+  session_connection_limit = -1
+  session_max_seconds      = 2
+  default_port             = 6379
+  host_source_ids = [
+    boundary_host_set_static.redis.id
+  ]
+}
+
+resource "boundary_host_static" "mssql" {
+  type        = "static"
+  name        = "mssql"
+  description = "Private mssql container"
+  # DNS set via docker-compose
+  address         = "mssql"
+  host_catalog_id = boundary_host_catalog_static.databases.id
+}
+
+resource "boundary_host_set_static" "mssql" {
+  type            = "static"
+  name            = "mssql"
+  description     = "Host set for mssql containers"
+  host_catalog_id = boundary_host_catalog_static.databases.id
+  host_ids        = [boundary_host_static.mssql.id]
+}
+resource "boundary_target" "mssql" {
+  type                     = "tcp"
+  name                     = "mssql"
+  description              = "Microsoft SQL server"
+  scope_id                 = boundary_scope.project.id
+  session_connection_limit = -1
+  session_max_seconds      = 2
+  default_port             = 1433
+  host_source_ids = [
+    boundary_host_set_static.local.id
+  ]
+}
+
+
+resource "random_shuffle" "group" {
+  input = [
+    for o in boundary_user.user : o.id
+  ]
+  result_count = floor(length(var.users) / 4)
+  count        = floor(length(var.users) / 2)
+}
+
+resource "random_pet" "group" {
+  length = 2
+  count  = length(var.users) / 2
+}
+
+resource "boundary_group" "group" {
+    for_each = {
+        for k, v in random_shuffle.group : k => v.id
+    }
+    name        = random_pet.group[each.key].id
+    description = "Group: ${random_pet.group[each.key].id}"
+    member_ids = tolist(random_shuffle.group[each.key].result)
+    scope_id = boundary_scope.org.id
+}
+
+output "boundary_auth_method_password" {
+  value = boundary_auth_method_password.password.id
+}
+
+output "boundary_connect_syntax" {
+  value       = <<EOT
+
+# https://learn.hashicorp.com/tutorials/boundary/oss-getting-started-connect?in=boundary/oss-getting-started
+
+boundary authenticate password -login-name mark -auth-method-id ${boundary_auth_method_password.password.id}
+
+EOT
+  description = "Boundary Authenticate"
+}
+
+# https://registry.terraform.io/providers/hashicorp/boundary/latest/docs/resources/auth_method_oidc
 #resource "boundary_auth_method_oidc" "provider" {
 #  name               = "<oidc provider>"
 #  description        = "OIDC auth method for AAD"

--- a/deployment/kube/boundary/accounts.tf
+++ b/deployment/kube/boundary/accounts.tf
@@ -1,9 +1,9 @@
-resource "boundary_account" "user" {
+resource "boundary_account_password" "user" {
   for_each       = var.users
-  name           = each.key
-  description    = "User account for ${each.key}"
+  name           = lower(each.key)
+  description    = "Account password for ${each.key}"
+  auth_method_id = boundary_auth_method_password.password.id
   type           = "password"
   login_name     = lower(each.key)
   password       = "foofoofoo"
-  auth_method_id = boundary_auth_method.password.id
 }

--- a/deployment/kube/boundary/auth_method.tf
+++ b/deployment/kube/boundary/auth_method.tf
@@ -1,6 +1,5 @@
-resource "boundary_auth_method" "password" {
+resource "boundary_auth_method_password" "password" {
   name        = "org_password_auth"
   description = "Password auth method for org"
-  type        = "password"
   scope_id    = boundary_scope.org.id
 }

--- a/deployment/kube/boundary/boundary.tf
+++ b/deployment/kube/boundary/boundary.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     boundary = {
       source  = "hashicorp/boundary"
-      version = "1.0.5"
+      version = "1.0.9"
     }
   }
 }
@@ -17,4 +17,9 @@ kms "aead" {
   key_id = "global_recovery"
 }
 EOT
+}
+
+
+output "boundary_auth_method_password" {
+  value = boundary_auth_method_password.password.id
 }

--- a/deployment/kube/boundary/groups.tf
+++ b/deployment/kube/boundary/groups.tf
@@ -1,0 +1,22 @@
+resource "random_shuffle" "group" {
+  input = [
+    for o in boundary_user.user : o.id
+  ]
+  result_count = floor(length(var.users) / 4)
+  count        = floor(length(var.users) / 2)
+}
+
+resource "random_pet" "group" {
+  length = 2
+  count  = length(var.users) / 2
+}
+
+resource "boundary_group" "group" {
+    for_each = {
+        for k, v in random_shuffle.group : k => v.id
+    }
+    name        = random_pet.group[each.key].id
+    description = "Group: ${random_pet.group[each.key].id}"
+    member_ids = tolist(random_shuffle.group[each.key].result)
+    scope_id = boundary_scope.org.id
+}

--- a/deployment/kube/boundary/host.tf
+++ b/deployment/kube/boundary/host.tf
@@ -1,15 +1,15 @@
-resource "boundary_host" "redis" {
+resource "boundary_host_static" "redis" {
   type            = "static"
   name            = "redis"
   description     = "redis container"
   address         = "redis.svc"
-  host_catalog_id = boundary_host_catalog.databases.id
+  host_catalog_id = boundary_host_catalog_static.databases.id
 }
 
-resource "boundary_host" "postgres" {
+resource "boundary_host_static" "postgres" {
   type            = "static"
   name            = "postgres"
   description     = "postgres container"
   address         = "postgres.svc"
-  host_catalog_id = boundary_host_catalog.databases.id
+  host_catalog_id = boundary_host_catalog_static.databases.id
 }

--- a/deployment/kube/boundary/host_catalog.tf
+++ b/deployment/kube/boundary/host_catalog.tf
@@ -1,6 +1,5 @@
-resource "boundary_host_catalog" "databases" {
+resource "boundary_host_catalog_static" "databases" {
   name        = "databases"
   description = "Database targets"
-  type        = "static"
-  scope_id    = boundary_scope.project.id
+  scope_id = boundary_scope.project.id
 }

--- a/deployment/kube/boundary/host_set.tf
+++ b/deployment/kube/boundary/host_set.tf
@@ -1,15 +1,15 @@
-resource "boundary_host_set" "redis_containers" {
+resource "boundary_host_set_static" "redis_containers" {
   type            = "static"
   name            = "redis_containers"
   description     = "Host set for redis containers"
-  host_catalog_id = boundary_host_catalog.databases.id
-  host_ids        = [boundary_host.redis.id]
+  host_catalog_id = boundary_host_catalog_static.databases.id
+  host_ids        = [boundary_host_static.redis.id]
 }
 
-resource "boundary_host_set" "postgres_containers" {
+resource "boundary_host_set_static" "postgres_containers" {
   type            = "static"
   name            = "postgres_containers"
   description     = "Host set for postgres containers"
-  host_catalog_id = boundary_host_catalog.databases.id
-  host_ids        = [boundary_host.postgres.id]
+  host_catalog_id = boundary_host_catalog_static.databases.id
+  host_ids        = [boundary_host_static.postgres.id]
 }

--- a/deployment/kube/boundary/roles.tf
+++ b/deployment/kube/boundary/roles.tf
@@ -2,8 +2,10 @@ resource "boundary_role" "global_anon_listing" {
   scope_id = boundary_scope.global.id
   grant_strings = [
     "id=*;type=auth-method;actions=list,authenticate",
-    "type=scope;actions=list",
-    "id={{account.id}};actions=read,change-password"
+    "id=*;type=scope;actions=*",
+    "id={{account.id}};actions=read,change-password",
+    "id=*;type=host-catalog;actions=*",
+    "type=host-catalog;actions=list"
   ]
   principal_ids = ["u_anon"]
 }
@@ -12,11 +14,14 @@ resource "boundary_role" "org_anon_listing" {
   scope_id = boundary_scope.org.id
   grant_strings = [
     "id=*;type=auth-method;actions=list,authenticate",
-    "type=scope;actions=list",
-    "id={{account.id}};actions=read,change-password"
+    "id=*;type=scope;actions=*",
+    "id={{account.id}};actions=read,change-password",
+    "id=*;type=host-catalog;actions=*",
+    "type=host-catalog;actions=list"
   ]
   principal_ids = ["u_anon"]
 }
+
 resource "boundary_role" "org_admin" {
   scope_id       = "global"
   grant_scope_id = boundary_scope.org.id
@@ -35,4 +40,17 @@ resource "boundary_role" "proj_admin" {
     [for user in boundary_user.user : user.id],
     ["u_auth"]
   )
+}
+
+resource "boundary_role" "proj_anon_listing" {
+  scope_id       = boundary_scope.org.id
+  grant_scope_id = boundary_scope.project.id
+  grant_strings = [
+    "id=*;type=auth-method;actions=list,authenticate",
+    "id=*;type=scope;actions=*",
+    "id={{account.id}};actions=read,change-password",
+    "id=*;type=host-catalog;actions=*",
+    "type=host-catalog;actions=list"
+  ]
+  principal_ids = ["u_anon"]
 }

--- a/deployment/kube/boundary/targets.tf
+++ b/deployment/kube/boundary/targets.tf
@@ -6,9 +6,9 @@ resource "boundary_target" "redis" {
   session_connection_limit = -1
   session_max_seconds      = 10000
   default_port             = 6379
-  host_set_ids = [
-    boundary_host_set.redis_containers.id
-  ]
+  # host_set_ids = [
+  #   boundary_host_set_static.redis_containers.id
+  # ]
 }
 
 resource "boundary_target" "postgres" {
@@ -19,7 +19,7 @@ resource "boundary_target" "postgres" {
   session_connection_limit = -1
   session_max_seconds      = 10000
   default_port             = 5432
-  host_set_ids = [
-    boundary_host_set.postgres_containers.id
-  ]
+  # host_set_ids = [
+  #   boundary_host_set_static.postgres_containers.id
+  # ]
 }

--- a/deployment/kube/boundary/users.tf
+++ b/deployment/kube/boundary/users.tf
@@ -2,6 +2,6 @@ resource "boundary_user" "user" {
   for_each    = var.users
   name        = each.key
   description = "User resource for ${each.key}"
-  account_ids = [boundary_account.user[each.value].id]
+  account_ids = [boundary_account_password.user[each.value].id]
   scope_id    = boundary_scope.org.id
 }

--- a/deployment/kube/boundary/vars.tf
+++ b/deployment/kube/boundary/vars.tf
@@ -5,6 +5,31 @@ variable "addr" {
 variable "users" {
   type = set(string)
   default = [
+    "jim",
+    "mike",
+    "todd",
+    "randy",
+    "susmitha",
     "jeff",
+    "pete",
+    "harold",
+    "patrick",
+    "jonathan",
+    "yoko",
+    "brandon",
+    "kyle",
+    "justin",
+    "melissa",
+    "paul",
+    "mitchell",
+    "armon",
+    "andy",
+    "ben",
+    "kristopher",
+    "kris",
+    "chris",
+    "swarna",
+    "mark",
+    "julia",
   ]
 }

--- a/deployment/kube/kubernetes/boundary.tf
+++ b/deployment/kube/kubernetes/boundary.tf
@@ -34,7 +34,7 @@ resource "kubernetes_deployment" "boundary" {
 
         init_container {
           name  = "boundary-init"
-          image = "hashicorp/boundary:0.1.8"
+          image = "hashicorp/boundary:latest"
           args = [
             "database",
             "init",
@@ -61,7 +61,7 @@ resource "kubernetes_deployment" "boundary" {
         }
 
         container {
-          image = "hashicorp/boundary:0.1.8"
+          image = "hashicorp/boundary:latest"
           name  = "boundary"
 
           volume_mount {

--- a/deployment/kube/kubernetes/kubernetes.tf
+++ b/deployment/kube/kubernetes/kubernetes.tf
@@ -1,4 +1,4 @@
 provider "kubernetes" {
   config_context_cluster = "minikube"
-  config_path = "~/.kube/config"
+  config_path            = "~/.kube/config"
 }

--- a/deployment/kube/main.tf
+++ b/deployment/kube/main.tf
@@ -10,3 +10,18 @@ module "boundary" {
   source = "./boundary"
   addr   = var.boundary_addr
 }
+
+output "boundary_auth_method_id" {
+  value = module.boundary.boundary_auth_method_password
+}
+
+output "boundary_connect_syntax" {
+  value       = <<EOT
+
+# https://learn.hashicorp.com/tutorials/boundary/oss-getting-started-connect?in=boundary/oss-getting-started
+
+boundary authenticate password -login-name mark -auth-method-id ${module.boundary.boundary_auth_method_password}
+
+EOT
+  description = "Boundary Authenticate"
+}


### PR DESCRIPTION
Hello Jeff et al,

This commit includes support for v1.0.9 Boundary TF Provider & v0.9.0 Boundary release i.e.:

- updates for deployments/docker
- updates for deployments/docker_cts
- updates for deployments/kube

Additional features include:

- dynamic group creation via random_pet & random_shuffle
- output for password auth method id