### PR TITLE
Truncating names on character-limited AWS resource

### DIFF
--- a/deployment/aws/aws/lb.tf
+++ b/deployment/aws/aws/lb.tf
@@ -1,5 +1,5 @@
 resource "aws_lb" "controller" {
-  name               = "${var.tag}-controller-${random_pet.test.id}"
+  name               = substr("${var.tag}-controller-${random_pet.test.id}", 0, 31)
   load_balancer_type = "network"
   internal           = false
   subnets            = aws_subnet.public.*.id
@@ -10,7 +10,7 @@ resource "aws_lb" "controller" {
 }
 
 resource "aws_lb_target_group" "controller" {
-  name     = "${var.tag}-controller-${random_pet.test.id}"
+  name     = substr("${var.tag}-controller-${random_pet.test.id}", 0, 31)
   port     = 9200
   protocol = "TCP"
   vpc_id   = aws_vpc.main.id


### PR DESCRIPTION
LB and Target Groups names are limited to 32-characters:

* https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_CreateLoadBalancer.html

Encountered an edge-case where the TF code tried to name my resources "marmoset" which ran afoul of this limitation.