### PR TITLE
update aws/docker/kube for 0.12 release

### DIFF
--- a/deployment/aws/README.md
+++ b/deployment/aws/README.md
@@ -8,6 +8,14 @@ This directory contains an AWS deployment example for Boundary using Terraform. 
 ## Setup
 - Make sure you have a local checkout of `github.com/hashicorp/boundary`
 - Build the `boundary` binary for linux using `XC_OSARCH=linux/amd64 make dev` or download from our [release page](https://boundaryproject.io/) on our docs site.
+```bash
+mkdir bin
+cd bin
+export BOUNDARY_VERSION=0.12.0
+curl -O https://releases.hashicorp.com/boundary/$(echo $BOUNDARY_VERSION)/boundary_$(echo $BOUNDARY_VERSION)_linux_amd64.zip
+unzip boundary_$(echo $BOUNDARY_VERSION)_linux_amd64.zip
+rm boundary_$(echo $BOUNDARY_VERSION)_linux_amd64.zip
+```
 - Provide appropriate AWS credentials through the command line
 
 ## Deploy
@@ -16,7 +24,7 @@ To deploy this example:
 1. Clone this repo by running `git clone https://github.com/hashicorp/boundary-reference-architecture.git`
 2. Navigate to `boundary-reference-architecture/deployment/aws`
     
-    If you want to change your AWS region, navigate to `aws/aws/net.tf` and change `region = <new-region>`
+    If you want to change your AWS region, navigate to `aws/aws/net.tf` and change `region = <new-region>` on line 6
     
     In addition, run the command `export AWS_REGION=<new-region>` to set the region in your command line
 3. Run `terraform init`
@@ -25,8 +33,10 @@ To deploy this example:
     For example: `terraform apply -target module.aws -var boundary_bin=/usr/bin`  
 
     If the public SSH key you want use is not located at `~/.ssh/id_rsa.pub` then you'll also need to override that value:
-    ```
-    terraform apply -target module.aws -var boundary_bin=<path to your binary> -var pub_ssh_key_path=<path to your SSH public key>
+    ```bash
+    terraform apply -target module.aws \
+    -var boundary_bin=<path to your binary> \
+    -var pub_ssh_key_path=<path to your SSH public key>
     ```
     If the private key is not named the same as the public key but without the .pub suffix and/or is not stored in the same directory, you can use the `priv_ssh_key_path` variable also to point to its location; otherwise its filename will be inferred from the filename of the public key.
 
@@ -46,7 +56,7 @@ To deploy this example:
 - Login on the CLI: 
 
 ```
-BOUNDARY_ADDR='http://<public-ipv4-dns>:9200' \
+BOUNDARY_ADDR='http://<boundary_url>:9200' \
   boundary authenticate password \
   -login-name=jim \
   -password foofoofoo \
@@ -60,7 +70,7 @@ You can also use this login name in the Boundary console that you navigated to i
 Connect to the target in the private subnet via Boundary:
 
 ```
-BOUNDARY_ADDR='http://<public-ipv4-dns>:9200' \
+BOUNDARY_ADDR='http://<boundary_url>:9200' \
   boundary connect ssh --username ubuntu -target-id ttcp_<generated_id>
 ```
 

--- a/deployment/aws/aws/cert.tf
+++ b/deployment/aws/aws/cert.tf
@@ -6,7 +6,6 @@ resource "tls_private_key" "boundary" {
 }
 
 resource "tls_self_signed_cert" "boundary" {
-  key_algorithm   = "RSA"
   private_key_pem = tls_private_key.boundary.private_key_pem
 
   subject {

--- a/deployment/aws/aws/net.tf
+++ b/deployment/aws/aws/net.tf
@@ -3,7 +3,7 @@
 
 provider "aws" {
   version = "~> 3.0"
-  region  = "us-east-1"
+  region  = "eu-west-2"
 }
 
 data "aws_availability_zones" "available" {

--- a/deployment/aws/boundary/main.tf
+++ b/deployment/aws/boundary/main.tf
@@ -5,7 +5,6 @@ terraform {
   required_providers {
     boundary = {
       source  = "hashicorp/boundary"
-      version = "1.0.5"
     }
   }
 }

--- a/deployment/aws/boundary/outputs.tf
+++ b/deployment/aws/boundary/outputs.tf
@@ -1,0 +1,7 @@
+output "boundary_auth_method_id" {
+  value = boundary_auth_method.password.id
+}
+
+output "boundary_ssh_target_id" {
+  value = boundary_target.backend_servers_ssh.id
+}

--- a/deployment/aws/boundary/targets.tf
+++ b/deployment/aws/boundary/targets.tf
@@ -8,7 +8,7 @@ resource "boundary_target" "backend_servers_ssh" {
   scope_id                 = boundary_scope.core_infra.id
   session_connection_limit = -1
   default_port             = 22
-  host_set_ids = [
+  host_source_ids = [
     boundary_host_set.backend_servers.id
   ]
 }
@@ -20,7 +20,7 @@ resource "boundary_target" "backend_servers_website" {
   scope_id                 = boundary_scope.core_infra.id
   session_connection_limit = -1
   default_port             = 8000
-  host_set_ids = [
+  host_source_ids = [
     boundary_host_set.backend_servers.id
   ]
 }

--- a/deployment/aws/destroy-tf-run.sh
+++ b/deployment/aws/destroy-tf-run.sh
@@ -1,0 +1,2 @@
+terraform state rm module.boundary
+terraform destroy

--- a/deployment/aws/outputs.tf
+++ b/deployment/aws/outputs.tf
@@ -1,0 +1,25 @@
+output "boundary_url" {
+  value = "http://${module.aws.boundary_lb}:9200"
+}
+
+
+output "Next_steps" {
+  value = <<EOF
+
+to continue exploring Boundary
+open the Web Admin ui on http://${module.aws.boundary_lb}:9200
+
+authenticate to the Terminal CLI
+export BOUNDARY_ADDR=http://${module.aws.boundary_lb}:9200
+
+
+boundary authenticate password \
+  -login-name=jim \
+  -auth-method-id=${module.boundary.boundary_auth_method_id}
+  #terraform generated password is foofoofo
+
+# SSH
+ boundary connect ssh --username ubuntu -target-id ${module.boundary.boundary_ssh_target_id}
+
+EOF
+}

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 5
 
   db-init:
-    image: hashicorp/boundary:0.9.0
+    image: hashicorp/boundary
     command: ["database", "init", "-config", "/boundary/boundary.hcl"]
     volumes:
       - "${PWD}/:/boundary:ro,z"
@@ -33,7 +33,7 @@ services:
 
 
   boundary:
-    image: hashicorp/boundary:0.9.0
+    image: hashicorp/boundary
     command: ["server", "-config", "/boundary/boundary.hcl"]
     volumes:
       - "${PWD}/:/boundary/"

--- a/deployment/docker/terraform/main.tf
+++ b/deployment/docker/terraform/main.tf
@@ -5,7 +5,6 @@ terraform {
   required_providers {
     boundary = {
       source  = "hashicorp/boundary"
-      version = "1.0.9"
     }
   }
 }
@@ -343,7 +342,12 @@ output "boundary_connect_syntax" {
 
 # https://learn.hashicorp.com/tutorials/boundary/oss-getting-started-connect?in=boundary/oss-getting-started
 
+export BOUNDARY_ADDR=http://localhost:9200
 boundary authenticate password -login-name mark -auth-method-id ${boundary_auth_method_password.password.id}
+# terraform generated password is foofoofoo
+
+#connect to redis
+boundary connect -exec redis-cli -target-id ${boundary_target.redis.id} -- -p {{boundary.port}} ping
 
 EOT
   description = "Boundary Authenticate"

--- a/deployment/kube/README.md
+++ b/deployment/kube/README.md
@@ -36,7 +36,7 @@ Run terraform apply against the kubernetes terraform module:
 $ terraform apply -target module.kubernetes
 ```
 
-Expose all 3 Boundary services running on minikube, on your local host using `kubectl port-forward` (you'll
+use minikube tunnel or expose all 3 Boundary services running on minikube, on your local host using `kubectl port-forward` (you'll
 need to do this in 3 separate long running shells):
 
 ```

--- a/deployment/kube/boundary/boundary.tf
+++ b/deployment/kube/boundary/boundary.tf
@@ -5,7 +5,6 @@ terraform {
   required_providers {
     boundary = {
       source  = "hashicorp/boundary"
-      version = "1.0.9"
     }
   }
 }

--- a/deployment/kube/boundary/outputs.tf
+++ b/deployment/kube/boundary/outputs.tf
@@ -1,0 +1,7 @@
+output "boundary_auth_method_id" {
+  value = boundary_auth_method_password.password.id
+}
+
+output "boundary_redis_target_id" {
+  value = boundary_target.redis.id
+}

--- a/deployment/kube/boundary/targets.tf
+++ b/deployment/kube/boundary/targets.tf
@@ -9,9 +9,9 @@ resource "boundary_target" "redis" {
   session_connection_limit = -1
   session_max_seconds      = 10000
   default_port             = 6379
-  # host_set_ids = [
-  #   boundary_host_set_static.redis_containers.id
-  # ]
+   host_source_ids = [
+     boundary_host_set_static.redis_containers.id
+   ]
 }
 
 resource "boundary_target" "postgres" {
@@ -22,7 +22,7 @@ resource "boundary_target" "postgres" {
   session_connection_limit = -1
   session_max_seconds      = 10000
   default_port             = 5432
-  # host_set_ids = [
-  #   boundary_host_set_static.postgres_containers.id
-  # ]
+   host_source_ids = [
+     boundary_host_set_static.postgres_containers.id
+   ]
 }

--- a/deployment/kube/destroy-tf-run.sh
+++ b/deployment/kube/destroy-tf-run.sh
@@ -1,0 +1,2 @@
+terraform state rm module.boundary
+terraform destroy

--- a/deployment/kube/kubernetes/boundary.tf
+++ b/deployment/kube/kubernetes/boundary.tf
@@ -127,7 +127,7 @@ resource "kubernetes_service" "boundary_controller" {
   }
 
   spec {
-    type = "ClusterIP"
+    type = "LoadBalancer"
     selector = {
       app = "boundary"
     }

--- a/deployment/kube/main.tf
+++ b/deployment/kube/main.tf
@@ -20,10 +20,15 @@ output "boundary_auth_method_id" {
 
 output "boundary_connect_syntax" {
   value       = <<EOT
-
+  
 # https://learn.hashicorp.com/tutorials/boundary/oss-getting-started-connect?in=boundary/oss-getting-started
 
-boundary authenticate password -login-name mark -auth-method-id ${module.boundary.boundary_auth_method_password}
+export BOUNDARY_ADDR=http://localhost:9200
+boundary authenticate password -login-name mark -auth-method-id ${module.boundary.boundary_auth_method_id}
+# terraform generated password is foofoofoo
+
+#connect to redis
+boundary connect -exec redis-cli -target-id ${module.boundary.boundary_redis_target_id} -- -h {{boundary.ip}} -p {{boundary.port}}
 
 EOT
   description = "Boundary Authenticate"


### PR DESCRIPTION
I've update the AWS , Docker , Kubernetes TF code to work on latests version of Boundary including the updated TF provider with hosts sources instead of host sets on targets.

I also added a facilitator to get the correct boundary version on the AWS documentation. 

as well as added tf outputs on all code to facilitate getting started with boundary after a succesfull TF run.

as well as a "destroy-tf-run" helped to ease clean up of resources. (without it the resources get destroyed before boundary resources and a destroy run fails)