### PR TITLE
AWS Boundary deployment compatibility updates (region parameterization + modern Boundary API/provider fixes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Boundary Binary
+**/boundary
+
 # Local .terraform directories
 **/.terraform/*
 

--- a/deployment/aws/aws/db.tf
+++ b/deployment/aws/aws/db.tf
@@ -5,7 +5,7 @@ resource "aws_db_instance" "boundary" {
   allocated_storage   = 20
   storage_type        = "gp2"
   engine              = "postgres"
-  engine_version      = "14.2"
+  engine_version      = "14.22"
   instance_class      = "db.t3.micro"
   name                = "boundary"
   username            = "boundary"

--- a/deployment/aws/aws/install/install.sh
+++ b/deployment/aws/aws/install/install.sh
@@ -28,7 +28,7 @@ sudo chown boundary:boundary /etc/${NAME}-${TYPE}.hcl
 sudo chown boundary:boundary /usr/local/bin/boundary
 
 # Make sure to initialize the DB before starting the service. This will result in
-# a database already initizalized warning if another controller or worker has done this 
+# a database already initizalized warning if another controller or worker has done this
 # already, making it a lazy, best effort initialization
 if [ "${TYPE}" = "controller" ]; then
   sudo /usr/local/bin/boundary database init -skip-auth-method-creation -skip-host-resources-creation -skip-scopes-creation -skip-target-creation -config /etc/${NAME}-${TYPE}.hcl || true

--- a/deployment/aws/aws/install/worker.hcl.tpl
+++ b/deployment/aws/aws/install/worker.hcl.tpl
@@ -18,9 +18,9 @@ worker {
 	public_addr = "${public_ip}"
 	name = "demo-worker-${name_suffix}"
 	description = "A default worker created for demonstration"
-	controllers = [
+	initial_upstreams = [
 %{ for ip in controller_ips ~}
-    "${ip}",
+    "${ip}:9201",
 %{ endfor ~}
   ]
 }

--- a/deployment/aws/aws/net.tf
+++ b/deployment/aws/aws/net.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 provider "aws" {
-  region  = "us-west-2"
+  region  = var.aws_region
 }
 
 data "aws_availability_zones" "available" {

--- a/deployment/aws/aws/net.tf
+++ b/deployment/aws/aws/net.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 provider "aws" {
-  region  = "us-east-1"
+  region  = "us-west-2"
 }
 
 data "aws_availability_zones" "available" {

--- a/deployment/aws/aws/vars.tf
+++ b/deployment/aws/aws/vars.tf
@@ -65,3 +65,7 @@ variable "tls_disabled" {
 variable "kms_type" {
   default = "aws"
 }
+
+variable "aws_region" {
+  default = "us-west-2"
+}

--- a/deployment/aws/boundary/roles.tf
+++ b/deployment/aws/boundary/roles.tf
@@ -7,9 +7,9 @@
 resource "boundary_role" "global_anon_listing" {
   scope_id = boundary_scope.global.id
   grant_strings = [
-    "id=*;type=auth-method;actions=list,authenticate",
+    "ids=*;type=auth-method;actions=list,authenticate",
     "type=scope;actions=list",
-    "id={{account.id}};actions=read,change-password"
+    "ids={{account.id}};actions=read,change-password"
   ]
   principal_ids = ["u_anon"]
 }
@@ -20,9 +20,9 @@ resource "boundary_role" "global_anon_listing" {
 resource "boundary_role" "org_anon_listing" {
   scope_id = boundary_scope.org.id
   grant_strings = [
-    "id=*;type=auth-method;actions=list,authenticate",
+    "ids=*;type=auth-method;actions=list,authenticate",
     "type=scope;actions=list",
-    "id={{account.id}};actions=read,change-password"
+    "ids={{account.id}};actions=read,change-password"
   ]
   principal_ids = ["u_anon"]
 }
@@ -33,41 +33,53 @@ resource "boundary_role" "org_admin" {
   scope_id       = boundary_scope.global.id
   grant_scope_id = boundary_scope.org.id
   grant_strings = [
-    "id=*;type=*;actions=*"
+    "ids=*;type=*;actions=*"
   ]
   principal_ids = concat(
     [for user in boundary_user.backend : user.id],
     [for user in boundary_user.frontend : user.id],
   )
+
+  lifecycle {
+    ignore_changes = [grant_scope_id]
+  }
 }
 
 # Adds a read-only role in the global scope granting read-only access
 # to all resources within the org scope and adds principals from the 
 # leadership team to the role
 resource "boundary_role" "org_readonly" {
-  name        = "readonly"
+  name        = "org_readonly"
   description = "Read-only role"
   principal_ids = [
     boundary_group.leadership.id
   ]
   grant_strings = [
-    "id=*;type=*;actions=read"
+    "ids=*;type=*;actions=read"
   ]
   scope_id       = boundary_scope.global.id
   grant_scope_id = boundary_scope.org.id
+
+  lifecycle {
+    ignore_changes = [grant_scope_id]
+  }
 }
 
 # Adds an org-level role granting administrative permissions within the core_infra project
 resource "boundary_role" "project_admin" {
-  name           = "core_infra_admin"
+  name           = "core_infra_admin_custom"
   description    = "Administrator role for core infra"
   scope_id       = boundary_scope.org.id
   grant_scope_id = boundary_scope.core_infra.id
   grant_strings = [
-    "id=*;type=*;actions=*"
+    "ids=*;type=*;actions=*"
   ]
   principal_ids = concat(
     [for user in boundary_user.backend : user.id],
     [for user in boundary_user.frontend : user.id],
   )
+
+  lifecycle {
+    ignore_changes = [grant_scope_id]
+  }
 }

--- a/deployment/aws/boundary/targets.tf
+++ b/deployment/aws/boundary/targets.tf
@@ -8,7 +8,7 @@ resource "boundary_target" "backend_servers_ssh" {
   scope_id                 = boundary_scope.core_infra.id
   session_connection_limit = -1
   default_port             = 22
-  host_set_ids = [
+  host_source_ids = [
     boundary_host_set.backend_servers.id
   ]
 }
@@ -20,7 +20,7 @@ resource "boundary_target" "backend_servers_website" {
   scope_id                 = boundary_scope.core_infra.id
   session_connection_limit = -1
   default_port             = 8000
-  host_set_ids = [
+  host_source_ids = [
     boundary_host_set.backend_servers.id
   ]
 }


### PR DESCRIPTION
This PR includes all changes to make the AWS deployment path work reliably with current Boundary/Terraform behavior.

The original fork state had several drift points versus current cloud/provider/runtime behavior:

- Hardcoded AWS region handling
- Outdated Postgres engine version
- Boundary config/API changes (id → ids, host_set_ids deprecation, worker upstream config changes)
- Runtime issues during worker/controller startup and target host source reconciliation

**Changes**

- Parameterized AWS provider region and set default to `us-west-2` in [net.tf](c:\Dev\boundary-reference-architecture\deployment\aws\aws\net.tf) and [vars.tf](c:\Dev\boundary-reference-architecture\deployment\aws\aws\vars.tf).
- Updated RDS Postgres engine version from `14.2` to `14.22` in [db.tf](c:\Dev\boundary-reference-architecture\deployment\aws\aws\db.tf).
- Added a gitignore rule for Boundary binaries in [.gitignore](c:\Dev\boundary-reference-architecture\.gitignore).
- Normalized install script formatting/whitespace in [install.sh](c:\Dev\boundary-reference-architecture\deployment\aws\aws\install\install.sh).
- Updated worker config template from `controllers` to `initial_upstreams` and added `:9201` to upstream controller addresses in [worker.hcl.tpl](c:\Dev\boundary-reference-architecture\deployment\aws\aws\install\worker.hcl.tpl).
- Updated Boundary role grant strings from `id=` to `ids=` in [roles.tf](c:\Dev\boundary-reference-architecture\deployment\aws\boundary\roles.tf).
- Renamed conflicting role names (`readonly` → `org_readonly`, `core_infra_admin` → `core_infra_admin_custom`) in [roles.tf](c:\Dev\boundary-reference-architecture\deployment\aws\boundary\roles.tf).
- Added lifecycle compatibility guards (`ignore_changes = [grant_scope_id]`) for roles in [roles.tf](c:\Dev\boundary-reference-architecture\deployment\aws\boundary\roles.tf).
- Replaced deprecated `host_set_ids` with `host_source_ids` for targets in [targets.tf](c:\Dev\boundary-reference-architecture\deployment\aws\boundary\targets.tf).